### PR TITLE
Fix the Player bug that allow him to climb steep slopes

### DIFF
--- a/UOP1_Project/Assets/Scripts/Characters/Character.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/Character.cs
@@ -16,6 +16,11 @@ public class Character : MonoBehaviour
     [Tooltip("The maximum speed reached when falling (in units/frame)")] public float maxFallSpeed = 50f;
     [Tooltip("Each frame while jumping, gravity will be multiplied by this amount in an attempt to 'cancel it' (= jump higher)")] public float gravityDivider = .6f;
 
+    //Peventing Player from climbing up slopes
+    private float slopeLimit = 30f;
+    private Vector3 hitNormal;
+    private bool canJump;
+
     private float gravityContributionMultiplier = 0f; //The factor which determines how much gravity is affecting verticalMovement
     private bool isJumping = false; //If true, a jump is in effect and the player is holding the jump button
     private float jumpBeginTime = -Mathf.Infinity; //Time of the last jump
@@ -27,6 +32,7 @@ public class Character : MonoBehaviour
     private void Awake()
     {
         characterController = GetComponent<CharacterController>();
+        slopeLimit = characterController.slopeLimit;
     }
 
     private void Update()
@@ -98,6 +104,16 @@ public class Character : MonoBehaviour
                 ref turnSmoothSpeed,
                 turnSmoothTime);
         }
+
+        if (!(Vector3.Angle(Vector3.up, hitNormal) <= slopeLimit))
+        {
+            canJump = false;
+        }
+        else
+        {
+            canJump = true;
+
+        }
     }
 
     //---- COMMANDS ISSUED BY OTHER SCRIPTS ----
@@ -109,7 +125,7 @@ public class Character : MonoBehaviour
 
     public void Jump()
     {
-        if (characterController.isGrounded)
+        if (characterController.isGrounded && canJump)
         {
             isJumping = true;
             jumpBeginTime = Time.time;
@@ -121,5 +137,10 @@ public class Character : MonoBehaviour
     public void CancelJump()
     {
         isJumping = false; //This will stop the reduction to the gravity, which will then quickly pull down the character
+    }
+
+    private void OnControllerColliderHit(ControllerColliderHit hit)
+    {
+        hitNormal = hit.normal;
     }
 }

--- a/UOP1_Project/Packages/packages-lock.json
+++ b/UOP1_Project/Packages/packages-lock.json
@@ -119,7 +119,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.14",
+      "version": "1.1.16",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/UOP1_Project/ProjectSettings/ProjectVersion.txt
+++ b/UOP1_Project/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.4.7f1
-m_EditorVersionWithRevision: 2019.4.7f1 (e992b1a16e65)
+m_EditorVersion: 2019.4.8f1
+m_EditorVersionWithRevision: 2019.4.8f1 (60781d942082)

--- a/UOP1_Project/ProjectSettings/QualitySettings.asset
+++ b/UOP1_Project/ProjectSettings/QualitySettings.asset
@@ -21,7 +21,7 @@ QualitySettings:
     skinWeights: 2
     textureQuality: 0
     anisotropicTextures: 1
-    antiAliasing: 0
+    antiAliasing: 2
     softParticles: 0
     softVegetation: 1
     realtimeReflectionProbes: 1


### PR DESCRIPTION
I made a really quick fix to the bug @ciro-unity commented in this issue: https://github.com/UnityTechnologies/open-project-1/issues/8.

This is done by obtaining the normal of the surface the Player's character controller is hitting in every frame. If this angle is gratter than the specified in the Chareacter Controller Component, then a boolean paramenter called "canJump" is set to false. 
If "canJump" = false, the Player can´t jump.