### PR TITLE
Add Camera Sensitivity

### DIFF
--- a/UOP1_Project/Assets/Scripts/CameraManager.cs
+++ b/UOP1_Project/Assets/Scripts/CameraManager.cs
@@ -9,6 +9,15 @@ public class CameraManager : MonoBehaviour
 	public InputReader inputReader;
     public CinemachineFreeLook freeLookVCam;
 
+ 	[Tooltip("General multiplier for camera sensitivity/speed")]
+	public float cameraSensitivity = 7.0f;
+
+ 	private void Awake()
+    {
+		// Don't allow the camera to be slower than default and then also 20+ gets pretty crazy.
+        cameraSensitivity = Mathf.Clamp(cameraSensitivity, 1.0f, 20.0f);
+    }
+
 	private void OnEnable()
 	{
 		inputReader.cameraMoveEvent += OnCameraMove;
@@ -24,7 +33,7 @@ public class CameraManager : MonoBehaviour
 
 	private void OnCameraMove(Vector2 cameraMovement)
 	{
-		freeLookVCam.m_XAxis.m_InputAxisValue = cameraMovement.x * Time.smoothDeltaTime;
-		freeLookVCam.m_YAxis.m_InputAxisValue = cameraMovement.y * Time.smoothDeltaTime;
+		freeLookVCam.m_XAxis.m_InputAxisValue = cameraMovement.x * Time.smoothDeltaTime * cameraSensitivity;
+		freeLookVCam.m_YAxis.m_InputAxisValue = cameraMovement.y * Time.smoothDeltaTime * cameraSensitivity;
 	}
 }

--- a/UOP1_Project/Assets/Scripts/CameraManager.cs
+++ b/UOP1_Project/Assets/Scripts/CameraManager.cs
@@ -10,13 +10,8 @@ public class CameraManager : MonoBehaviour
     public CinemachineFreeLook freeLookVCam;
 
  	[Tooltip("General multiplier for camera sensitivity/speed")]
+	[Range(1.0f, 20.0f)]
 	public float cameraSensitivity = 7.0f;
-
- 	private void Awake()
-    {
-		// Don't allow the camera to be slower than default and then also 20+ gets pretty crazy.
-        cameraSensitivity = Mathf.Clamp(cameraSensitivity, 1.0f, 20.0f);
-    }
 
 	private void OnEnable()
 	{

--- a/UOP1_Project/Assets/Scripts/CameraManager.cs
+++ b/UOP1_Project/Assets/Scripts/CameraManager.cs
@@ -11,7 +11,7 @@ public class CameraManager : MonoBehaviour
 
  	[Tooltip("General multiplier for camera sensitivity/speed")]
 	[Range(1.0f, 20.0f)]
-	public float cameraSensitivity = 7.0f;
+	[SerializeField] private float cameraSensitivity = 7.0f;
 
 	private void OnEnable()
 	{


### PR DESCRIPTION
This commit adds a variable to CameraManager.cs that will allow the
sensitivity/speed of the player camera to be modified. By default, the
camera sensitivity is now quicker.

### Note: I'd love to learn how to write some unit tests for this; if someone knows how to do that, let me know.