### PR TITLE
Fixed the ability to climb steep surfaces & getting stuck mid-air

### DIFF
--- a/UOP1_Project/Assets/Scripts/Characters/Character.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/Character.cs
@@ -88,23 +88,8 @@ public class Character : MonoBehaviour
         movementVector.y = verticalMovement;
         characterController.Move(movementVector * Time.deltaTime);
 
-        if (characterController.isGrounded) {
-            //Check if underneath the character is stable
-            isUnderneathStable = false; //By default, underneath is not stable
-            RaycastHit hit;
-            Ray ray = new Ray(transform.position + characterController.center, Vector3.down);
-            if (Physics.Raycast(ray, out hit, Mathf.Infinity)) {
-                float underneathSlopeAngle = Vector3.Angle(transform.up, hit.normal);
-                if (underneathSlopeAngle <= characterController.slopeLimit) {
-                    //We found a stable underneath
-                    isUnderneathStable = true;
-                } else {
-                    //Add a slide movement along the underneath slope direction
-                    Vector3 underneathSlopeDirection = Vector3.Cross(hit.normal, Vector3.Cross(hit.normal, Vector3.up));
-                    characterController.Move(underneathSlopeDirection * gravityMultiplier * Time.deltaTime);
-                }
-            }
-        }
+        //Check if underneath is stable and slide accordingly
+        CheckUnderneathStabilityAndSlide();
 
         //Rotate to the movement direction
         movementVector.y = 0f;
@@ -139,6 +124,28 @@ public class Character : MonoBehaviour
                 gravityContributionMultiplier = 1f;
 
                 verticalMovement = 0f;
+            }
+        }
+    }
+
+    private void CheckUnderneathStabilityAndSlide()
+    {
+        isUnderneathStable = false; //By default, underneath is not stable
+
+        if (characterController.isGrounded) {
+            //Perform a downward raycast to check underneath the character
+            RaycastHit hit;
+            Ray ray = new Ray(transform.position + characterController.center, Vector3.down);
+            if (Physics.Raycast(ray, out hit, Mathf.Infinity)) {
+                float underneathSlopeAngle = Vector3.Angle(transform.up, hit.normal);
+                if (underneathSlopeAngle <= characterController.slopeLimit) {
+                    //We found a stable underneath
+                    isUnderneathStable = true;
+                } else {
+                    //Add a slide movement along the underneath slope direction
+                    Vector3 underneathSlopeDirection = Vector3.Cross(hit.normal, Vector3.Cross(hit.normal, Vector3.up)).normalized;
+                    characterController.Move(underneathSlopeDirection * gravityMultiplier * Time.deltaTime);
+                }
             }
         }
     }

--- a/UOP1_Project/Assets/Scripts/Characters/Character.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/Character.cs
@@ -137,9 +137,8 @@ public class Character : MonoBehaviour
         isUnderneathStable = true;
 
         if (characterController.isGrounded) {
-            //Perform a downward raycast to check underneath the character
+            //Perform multiple downward spherecast to check underneath the character every slope
             Ray ray = new Ray(transform.position + characterController.center, Vector3.down);
-            //if (Physics.Raycast(ray, out hit, Mathf.Infinity)) {
             var hits = Physics.SphereCastAll(ray, characterController.radius, characterController.height / 2 + characterController.skinWidth);
             Vector3 underneathAllSlopesDirection = Vector3.zero;
             foreach (var hit in hits) { 


### PR DESCRIPTION
# Description

By introducing `isUnderneathStable` property, we will know if the character is under a stable or instable surface.
A surface is considered stable if the slope angle is lower or equal to the character slope angle limit.

I used a downward `SphereCastAll` that will calculate the total unstable slopes direction and slide the character accordingly. The steeper it is, the faster the character will fall.
It will correctly handle multiple unstable slopes (shown in the gif). It won't be interfering with pushing an object or collision with the head since it is not using `OnControllerColliderHit`.

![2020-10-05_12-03-28](https://user-images.githubusercontent.com/2796935/95036572-535f8f80-0703-11eb-9a16-cdbfceca3c2e.gif)

PS: I saw there was already other PRs that were also trying to fix it but I wanted to share also my solution. Don't hesitate to close it if you find it redundant/irrelevant.

Fixes Issues #8 & #48 