### PR TITLE
bug-fix Character can jump on inclined surfaces

### DIFF
--- a/UOP1_Project/Assets/Scripts/Characters/Character.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/Character.cs
@@ -24,7 +24,7 @@ public class Character : MonoBehaviour
     private Vector3 inputVector; //Initial input horizontal movement (y == 0f)
     private Vector3 movementVector; //Final movement vector
     private bool isAboveSlopeLimit = false; // Used to check if current ground is above Slope Limit set on Character Controller
-    private bool isSliding = false; // Detects if character is currently sliding down a slope
+    public bool isSliding = false; // Detects if character is currently sliding down a slope
     private Vector3 slideMovement; //Movement direction of character sliding down a slope
 
     private void Awake()
@@ -72,6 +72,10 @@ public class Character : MonoBehaviour
         }
         else
         {
+            if(characterController.velocity.magnitude == 0) {
+                isSliding = false;
+            }
+
             if(isSliding)
             {
                 inputVector = slideMovement;
@@ -114,7 +118,9 @@ public class Character : MonoBehaviour
 
         // Calculates if hit vector is above slopelimit set on Character Controller
         isAboveSlopeLimit = (Vector3.Angle (Vector3.up, hit.normal) >= characterController.slopeLimit);
-        slideMovement = isAboveSlopeLimit;
+        if (isAboveSlopeLimit) {
+            isSliding = true;
+        }
 
         if (isMovingUpwards)
         {

--- a/UOP1_Project/Assets/Scripts/Characters/Character.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/Character.cs
@@ -114,15 +114,7 @@ public class Character : MonoBehaviour
 
         // Calculates if hit vector is above slopelimit set on Character Controller
         isAboveSlopeLimit = (Vector3.Angle (Vector3.up, hit.normal) >= characterController.slopeLimit);
-        slideMovement = new Vector3(hit.normal.x, hit.normal.y, hit.normal.z);
-
-        if (isAboveSlopeLimit) 
-        {
-            isSliding = true;
-        } else
-        {
-            isSliding = false;
-        }
+        slideMovement = isAboveSlopeLimit;
 
         if (isMovingUpwards)
         {

--- a/UOP1_Project/Assets/Scripts/Characters/Character.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/Character.cs
@@ -24,7 +24,7 @@ public class Character : MonoBehaviour
     private Vector3 inputVector; //Initial input horizontal movement (y == 0f)
     private Vector3 movementVector; //Final movement vector
     private bool isAboveSlopeLimit = false; // Used to check if current ground is above Slope Limit set on Character Controller
-    public bool isSliding = false; // Detects if character is currently sliding down a slope
+    private bool isSliding = false; // Detects if character is currently sliding down a slope
     private Vector3 slideMovement; //Movement direction of character sliding down a slope
 
     private void Awake()


### PR DESCRIPTION
Using Character Controller to check Slope limit
If the character is currently above Slope Limit he will begin sliding down
When below the slope limit, he will stop sliding.
Sliding does not turn the character (but it could be if animation wants him to slide down his butt)

Related to issue: https://github.com/UnityTechnologies/open-project-1/issues/8 #
#8 

Card: https://open.codecks.io/unity-open-project-1/decks/13/card/16f-player-can-climb-steep-surfaces