### PR TITLE
Changed Camera Move Event binding to Mouse delta X and scroll

### DIFF
--- a/UOP1_Project/Assets/Scenes/CharController.unity
+++ b/UOP1_Project/Assets/Scenes/CharController.unity
@@ -286,7 +286,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 233317031}
-  m_LocalRotation: {x: 0.18994758, y: -0.20527026, z: 0.040647585, w: 0.959235}
+  m_LocalRotation: {x: -0.057153553, y: 0.93753034, z: -0.18564963, w: -0.28862536}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -703,6 +703,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   inputReader: {fileID: 1724036687}
   freeLookVCam: {fileID: 1502793901}
+  cameraSensitivity: 7
 --- !u!4 &526256411
 Transform:
   m_ObjectHideFlags: 0
@@ -1434,7 +1435,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1069947040}
-  m_LocalRotation: {x: 0.18492083, y: -0.20548035, z: 0.0395719, w: 0.96021676}
+  m_LocalRotation: {x: -0.05564106, y: 0.93848985, z: -0.18073663, w: -0.28892076}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1832,7 +1833,7 @@ MonoBehaviour:
       m_LegacyHeadingDefinition: -1
       m_LegacyVelocityFilterStrength: -1
   m_YAxisRecentering:
-    m_enabled: 1
+    m_enabled: 0
     m_WaitTime: 2
     m_RecenteringTime: 3
     m_LegacyHeadingDefinition: -1
@@ -1840,7 +1841,7 @@ MonoBehaviour:
   m_XAxis:
     Value: 0
     m_SpeedMode: 0
-    m_MaxSpeed: 8000
+    m_MaxSpeed: 800
     m_AccelTime: 0.5
     m_DecelTime: 0.1
     m_InputAxisName: 
@@ -1887,7 +1888,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1502793900}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 4.712467, y: 6.307, z: -24.900238}
+  m_LocalPosition: {x: 6.2441106, y: 6.307, z: -7.5074224}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1069947042}
@@ -2587,8 +2588,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1961065787}
-  m_LocalRotation: {x: 0.18778463, y: -0.20536137, z: 0.04018472, w: 0.95966077}
-  m_LocalPosition: {x: 4.712467, y: 6.307, z: -24.900238}
+  m_LocalRotation: {x: -0.05650274, y: 0.9379465, z: -0.18353558, w: -0.2887535}
+  m_LocalPosition: {x: 6.2441106, y: 6.307, z: -7.5074224}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -2936,7 +2937,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2049112419}
-  m_LocalRotation: {x: 0.18778461, y: -0.20536137, z: 0.040184718, w: 0.9596608}
+  m_LocalRotation: {x: -0.05650273, y: 0.9379465, z: -0.18353559, w: -0.2887535}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:

--- a/UOP1_Project/Assets/Scripts/InputReader.cs
+++ b/UOP1_Project/Assets/Scripts/InputReader.cs
@@ -32,7 +32,15 @@ public class InputReader : MonoBehaviour, GameInput.IGameplayActions
 		gameInput.Gameplay.Disable();
 	}
 
-	public void OnAttack(InputAction.CallbackContext context)
+    private void Update()
+    {
+        Vector2 delta;
+        delta.x = Mouse.current.rightButton.isPressed ? Mouse.current.delta.ReadValue().x : 0;
+        delta.y = Mouse.current.scroll.ReadValue().y * 0.15f;
+        cameraMoveEvent.Invoke(delta);
+    }
+
+    public void OnAttack(InputAction.CallbackContext context)
 	{
 		if(attackEvent != null
 			&& context.phase == InputActionPhase.Started)
@@ -83,7 +91,7 @@ public class InputReader : MonoBehaviour, GameInput.IGameplayActions
 	{
 		if(cameraMoveEvent != null)
 		{
-			cameraMoveEvent.Invoke(context.ReadValue<Vector2>());
+            cameraMoveEvent.Invoke(context.ReadValue<Vector2>());
 		}
 	}
 }


### PR DESCRIPTION
The current implementation uses the unusual TFGH keys to orbit camera. With this fix you can orbit with mouse delta X and zoom with mouse scroll. This overrides the current implementation and works for keyboard mouse setup only. Further works will be required to support multiple devices such as game pads. 