### PR TITLE
Remove newlines

### DIFF
--- a/UOP1_Project/Assets/Shaders/CustomLighting.hlsl
+++ b/UOP1_Project/Assets/Shaders/CustomLighting.hlsl
@@ -1,4 +1,4 @@
-﻿#ifndef CUSTOM_LIGHTING_INCLUDED
+#ifndef CUSTOM_LIGHTING_INCLUDED
 #define CUSTOM_LIGHTING_INCLUDED
 
 void MainLight_float(float3 WorldPos, out float3 Direction, out float3 Color, out float DistanceAtten, out float ShadowAtten)
@@ -22,9 +22,7 @@ void MainLight_float(float3 WorldPos, out float3 Direction, out float3 Color, ou
 
 	ShadowSamplingData shadowSamplingData = GetMainLightShadowSamplingData();
 	float shadowStrength = GetMainLightShadowStrength();
-	ShadowAtten = SampleShadowmap(shadowCoord, TEXTURE2D_ARGS(_MainLightShadowmapTexture,
-	sampler_MainLightShadowmapTexture),
-	shadowSamplingData, shadowStrength, false);
+	ShadowAtten = SampleShadowmap(shadowCoord, TEXTURE2D_ARGS(_MainLightShadowmapTexture, sampler_MainLightShadowmapTexture), shadowSamplingData, shadowStrength, false);
 #endif
 }
 


### PR DESCRIPTION
This is a combination between a question and maybe a fix.

I tried using the shader and it failed to run because of too few arguments to a macro. The only thing I could think of was that it doesn't like newlines for the arguments... And so I removed them. Now the shader works for me.

I'm not part of the game, so forgive me for not taking the official route. I hope this is useful. If not, close it and optionally tell me why this fix is wrong. I won't feel hurt either way 😄