### PR TITLE
FSM using MonoBehaviours. +Examples using SO and plain C# classes

### DIFF
--- a/UOP1_Project/Assets/Materials/CharacterFSM DoubleJump.mat
+++ b/UOP1_Project/Assets/Materials/CharacterFSM DoubleJump.mat
@@ -1,0 +1,90 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: CharacterFSM DoubleJump
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 2050
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.46
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0.5040141, g: 0.14509803, b: 0.6313726, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+--- !u!114 &5947275996608933956
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 1

--- a/UOP1_Project/Assets/Materials/CharacterFSM DoubleJump.mat.meta
+++ b/UOP1_Project/Assets/Materials/CharacterFSM DoubleJump.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 92f3ec47226d5f84a99bf8e6fd6fb736
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Materials/CharacterFSM.mat
+++ b/UOP1_Project/Assets/Materials/CharacterFSM.mat
@@ -1,0 +1,90 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: CharacterFSM
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 2050
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.46
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0.14509803, g: 0.5404915, b: 0.6313726, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+--- !u!114 &5947275996608933956
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 1

--- a/UOP1_Project/Assets/Materials/CharacterFSM.mat.meta
+++ b/UOP1_Project/Assets/Materials/CharacterFSM.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 01456733de0da8a468ac0fd76cc40be8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Prefabs/Pig FSM DoubleJump Variant.prefab
+++ b/UOP1_Project/Assets/Prefabs/Pig FSM DoubleJump Variant.prefab
@@ -1,0 +1,619 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &629777992960801286
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8743940001845795267}
+  - component: {fileID: 5790429022890288579}
+  m_Layer: 0
+  m_Name: Not_InputJumpCondition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8743940001845795267
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 629777992960801286}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6630325532401902007}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5790429022890288579
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 629777992960801286}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c723a9f1fc9a4dac920887b4fe00d45f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _inverse: 1
+--- !u!1 &3814485025028508022
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7935800598453982236}
+  - component: {fileID: 8441098717739482596}
+  m_Layer: 0
+  m_Name: To_IdleState_Transition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7935800598453982236
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3814485025028508022}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7160079263693555061}
+  m_Father: {fileID: 5941832070103798731}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8441098717739482596
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3814485025028508022}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25e5fedf33174467b668d49ac69cc614, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _targetState: {fileID: 7649439505105288828}
+--- !u!1 &5132118741995361586
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6630325532401902007}
+  - component: {fileID: 6389067435211776857}
+  m_Layer: 0
+  m_Name: To_SecondFallingState_Transition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6630325532401902007
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5132118741995361586}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 8743940001845795267}
+  m_Father: {fileID: 2021737209713001432}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6389067435211776857
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5132118741995361586}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25e5fedf33174467b668d49ac69cc614, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _targetState: {fileID: 7156618468096312968}
+--- !u!1 &5193361717647896523
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5988385546099312508}
+  - component: {fileID: 7171233961207438703}
+  m_Layer: 0
+  m_Name: To_DoubleJampingState_Transition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5988385546099312508
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5193361717647896523}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 475586247424395523}
+  m_Father: {fileID: 3141313800527101233}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7171233961207438703
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5193361717647896523}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25e5fedf33174467b668d49ac69cc614, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _targetState: {fileID: 6607745114570309446}
+--- !u!1 &5917852444301402679
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3094278434879881143}
+  - component: {fileID: 8259627300858646973}
+  m_Layer: 0
+  m_Name: To_SecondFallingState_Transition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3094278434879881143
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5917852444301402679}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7671980205163396114}
+  m_Father: {fileID: 2021737209713001432}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8259627300858646973
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5917852444301402679}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25e5fedf33174467b668d49ac69cc614, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _targetState: {fileID: 7156618468096312968}
+--- !u!1 &7014288254282529179
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2021737209713001432}
+  - component: {fileID: 6607745114570309446}
+  - component: {fileID: 2864782329043835911}
+  - component: {fileID: 665007546916232394}
+  m_Layer: 0
+  m_Name: DoubleJampingState
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2021737209713001432
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7014288254282529179}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6630325532401902007}
+  - {fileID: 3094278434879881143}
+  m_Father: {fileID: 3141313800985739936}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6607745114570309446
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7014288254282529179}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b864070d50743e1a4ca5bf3d302d2b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2864782329043835911
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7014288254282529179}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0db2b50989d34e1f809a980b45beff32, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _speedMultiplier: 1
+--- !u!114 &665007546916232394
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7014288254282529179}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64357be3bf86411493789ce4db3b71ee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &7122763322706523317
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 475586247424395523}
+  - component: {fileID: 8699141189334210513}
+  m_Layer: 0
+  m_Name: InputJumpCondition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &475586247424395523
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7122763322706523317}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5988385546099312508}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8699141189334210513
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7122763322706523317}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c723a9f1fc9a4dac920887b4fe00d45f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _inverse: 0
+--- !u!1 &7940332533471799080
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7671980205163396114}
+  - component: {fileID: 2852781413619795817}
+  m_Layer: 0
+  m_Name: TimeInStateCondition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7671980205163396114
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7940332533471799080}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3094278434879881143}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2852781413619795817
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7940332533471799080}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 011792c5973c4efebcecf7f5149dbf48, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _inverse: 0
+  _state: {fileID: 6607745114570309446}
+  _time: 0.1
+--- !u!1 &8627852393131869924
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5941832070103798731}
+  - component: {fileID: 7156618468096312968}
+  - component: {fileID: 6565965937960595299}
+  - component: {fileID: 5257511019967891382}
+  m_Layer: 0
+  m_Name: SecondFallingState
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5941832070103798731
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8627852393131869924}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7935800598453982236}
+  m_Father: {fileID: 3141313800985739936}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7156618468096312968
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8627852393131869924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b864070d50743e1a4ca5bf3d302d2b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6565965937960595299
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8627852393131869924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0db2b50989d34e1f809a980b45beff32, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _speedMultiplier: 1
+--- !u!114 &5257511019967891382
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8627852393131869924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 950c277402aa4059a06f96de71a830c5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &8870863172381070853
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7160079263693555061}
+  - component: {fileID: 3656227095275737351}
+  m_Layer: 0
+  m_Name: CharacterGroundedCondition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7160079263693555061
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8870863172381070853}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7935800598453982236}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3656227095275737351
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8870863172381070853}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 87c09c96d8d54db085330027f556ca3c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _inverse: 0
+--- !u!1001 &3141313801350603400
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 255504483, guid: 64339d0e2a3f0b541a7a824adeafc3d5, type: 3}
+      propertyPath: _time
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2051104809, guid: 64339d0e2a3f0b541a7a824adeafc3d5, type: 3}
+      propertyPath: inputReader
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 142431495074676108, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 92f3ec47226d5f84a99bf8e6fd6fb736, type: 2}
+    - target: {fileID: 6653959911160771788, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_Name
+      value: Pig FSM DoubleJump Variant
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.62
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -15.776
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8140630184192386969, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: inputReader
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8140630184192386969, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: gameplayCamera
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 64339d0e2a3f0b541a7a824adeafc3d5, type: 3}
+--- !u!114 &7649439505105288828 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4733411790445812980, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+    type: 3}
+  m_PrefabInstance: {fileID: 3141313801350603400}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b864070d50743e1a4ca5bf3d302d2b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &3141313800527101233 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1375461305, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+    type: 3}
+  m_PrefabInstance: {fileID: 3141313801350603400}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &3141313800985739936 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2051104808, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+    type: 3}
+  m_PrefabInstance: {fileID: 3141313801350603400}
+  m_PrefabAsset: {fileID: 0}

--- a/UOP1_Project/Assets/Prefabs/Pig FSM DoubleJump Variant.prefab.meta
+++ b/UOP1_Project/Assets/Prefabs/Pig FSM DoubleJump Variant.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 93e54cb6384095e49ba2e14fb5adae35
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Prefabs/Pig FSM Variant.prefab
+++ b/UOP1_Project/Assets/Prefabs/Pig FSM Variant.prefab
@@ -1,0 +1,1263 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &25463239
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 25463240}
+  - component: {fileID: 25463241}
+  m_Layer: 0
+  m_Name: To_FallingState_Transition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &25463240
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 25463239}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 255504482}
+  m_Father: {fileID: 1841197487}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &25463241
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 25463239}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25e5fedf33174467b668d49ac69cc614, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _targetState: {fileID: 6826380046016001597}
+--- !u!1 &178722956
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 178722957}
+  - component: {fileID: 178722958}
+  m_Layer: 0
+  m_Name: To_IdleState_Transition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &178722957
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 178722956}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1231336064}
+  m_Father: {fileID: 1563130587}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &178722958
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 178722956}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25e5fedf33174467b668d49ac69cc614, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _targetState: {fileID: 4733411790445812980}
+--- !u!1 &255504481
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 255504482}
+  - component: {fileID: 255504483}
+  m_Layer: 0
+  m_Name: TimeInStateCondition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &255504482
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 255504481}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 25463240}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &255504483
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 255504481}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 011792c5973c4efebcecf7f5149dbf48, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _inverse: 0
+  _state: {fileID: 1557974675271434763}
+  _time: 0.3
+--- !u!1 &379555584
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 379555585}
+  - component: {fileID: 379555586}
+  m_Layer: 0
+  m_Name: To_JampingState_Transition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &379555585
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 379555584}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 912778700}
+  - {fileID: 1753412449}
+  m_Father: {fileID: 828343235}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &379555586
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 379555584}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25e5fedf33174467b668d49ac69cc614, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _targetState: {fileID: 1557974675271434763}
+--- !u!1 &559298644
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 559298645}
+  - component: {fileID: 559298646}
+  m_Layer: 0
+  m_Name: CharacterGroundedCondition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &559298645
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 559298644}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.62, y: 0.307, z: -15.776}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1465815325}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &559298646
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 559298644}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 87c09c96d8d54db085330027f556ca3c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _inverse: 0
+--- !u!1 &713103976
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 713103977}
+  - component: {fileID: 713103978}
+  m_Layer: 0
+  m_Name: To_FallingState_Transition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &713103977
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 713103976}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1989832167}
+  m_Father: {fileID: 1841197487}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &713103978
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 713103976}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25e5fedf33174467b668d49ac69cc614, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _targetState: {fileID: 6826380046016001597}
+--- !u!1 &828343233
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 828343235}
+  - component: {fileID: 4733411790445812980}
+  - component: {fileID: 828343234}
+  m_Layer: 0
+  m_Name: IdleState
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &828343235
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 828343233}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2089516347}
+  - {fileID: 379555585}
+  m_Father: {fileID: 2051104808}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4733411790445812980
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 828343233}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b864070d50743e1a4ca5bf3d302d2b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &828343234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 828343233}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0457bfefcd8b4b5ead1b57eff4f6450f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &874001858
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 874001859}
+  - component: {fileID: 874001860}
+  m_Layer: 0
+  m_Name: InputMoveCondition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &874001859
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 874001858}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2089516347}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &874001860
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 874001858}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dfa227e9f8e142dc9c2f427390e0c498, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _inverse: 0
+--- !u!1 &912778699
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 912778700}
+  - component: {fileID: 912778701}
+  m_Layer: 0
+  m_Name: InputJumpCondition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &912778700
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 912778699}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 379555585}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &912778701
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 912778699}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c723a9f1fc9a4dac920887b4fe00d45f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _inverse: 0
+--- !u!1 &958474724
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 958474725}
+  - component: {fileID: 958474726}
+  m_Layer: 0
+  m_Name: To_IdleState_Transition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &958474725
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 958474724}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1507817290}
+  m_Father: {fileID: 1375461305}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &958474726
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 958474724}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25e5fedf33174467b668d49ac69cc614, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _targetState: {fileID: 4733411790445812980}
+--- !u!1 &1231336063
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1231336064}
+  - component: {fileID: 1231336065}
+  m_Layer: 0
+  m_Name: Not_InputMoveCondition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1231336064
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1231336063}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 178722957}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1231336065
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1231336063}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dfa227e9f8e142dc9c2f427390e0c498, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _inverse: 1
+--- !u!1 &1375461304
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1375461305}
+  - component: {fileID: 6826380046016001597}
+  - component: {fileID: 3779385866213979253}
+  - component: {fileID: 1375461306}
+  m_Layer: 0
+  m_Name: FallingState
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1375461305
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1375461304}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 958474725}
+  m_Father: {fileID: 2051104808}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6826380046016001597
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1375461304}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b864070d50743e1a4ca5bf3d302d2b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &3779385866213979253
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1375461304}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0db2b50989d34e1f809a980b45beff32, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _speedMultiplier: 1
+--- !u!114 &1375461306
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1375461304}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 950c277402aa4059a06f96de71a830c5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1465815324
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1465815325}
+  - component: {fileID: 1465815326}
+  m_Layer: 0
+  m_Name: To_JampingState_Transition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1465815325
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465815324}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.62, y: 0.307, z: -15.776}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1716584166}
+  - {fileID: 559298645}
+  m_Father: {fileID: 1563130587}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1465815326
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465815324}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25e5fedf33174467b668d49ac69cc614, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _targetState: {fileID: 1557974675271434763}
+--- !u!1 &1507817289
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1507817290}
+  - component: {fileID: 1507817291}
+  m_Layer: 0
+  m_Name: CharacterGroundedCondition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1507817290
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1507817289}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 958474725}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1507817291
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1507817289}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 87c09c96d8d54db085330027f556ca3c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _inverse: 0
+--- !u!1 &1563130586
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1563130587}
+  - component: {fileID: 3624877722083475732}
+  - component: {fileID: 1563130588}
+  - component: {fileID: 4277163704426772803}
+  m_Layer: 0
+  m_Name: MovingState
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1563130587
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1563130586}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1465815325}
+  - {fileID: 178722957}
+  - {fileID: 1635575639}
+  m_Father: {fileID: 2051104808}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3624877722083475732
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1563130586}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b864070d50743e1a4ca5bf3d302d2b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1563130588
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1563130586}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0db2b50989d34e1f809a980b45beff32, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _speedMultiplier: 1
+--- !u!114 &4277163704426772803
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1563130586}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 950c277402aa4059a06f96de71a830c5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1635575638
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1635575639}
+  - component: {fileID: 1635575640}
+  m_Layer: 0
+  m_Name: To_FallingState_Transition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1635575639
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1635575638}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1860645802}
+  m_Father: {fileID: 1563130587}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1635575640
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1635575638}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25e5fedf33174467b668d49ac69cc614, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _targetState: {fileID: 6826380046016001597}
+--- !u!1 &1716584165
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1716584166}
+  - component: {fileID: 1716584167}
+  m_Layer: 0
+  m_Name: InputJumpCondition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1716584166
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1716584165}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1465815325}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1716584167
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1716584165}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c723a9f1fc9a4dac920887b4fe00d45f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _inverse: 0
+--- !u!1 &1753412448
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1753412449}
+  - component: {fileID: 1753412450}
+  m_Layer: 0
+  m_Name: CharacterGroundedCondition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1753412449
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1753412448}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 379555585}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1753412450
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1753412448}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 87c09c96d8d54db085330027f556ca3c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _inverse: 0
+--- !u!1 &1841197485
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1841197487}
+  - component: {fileID: 1557974675271434763}
+  - component: {fileID: 4932437515371940025}
+  - component: {fileID: 1841197486}
+  m_Layer: 0
+  m_Name: JampingState
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1841197487
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1841197485}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 713103977}
+  - {fileID: 25463240}
+  m_Father: {fileID: 2051104808}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1557974675271434763
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1841197485}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b864070d50743e1a4ca5bf3d302d2b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4932437515371940025
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1841197485}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0db2b50989d34e1f809a980b45beff32, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _speedMultiplier: 1
+--- !u!114 &1841197486
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1841197485}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64357be3bf86411493789ce4db3b71ee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1860645801
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1860645802}
+  - component: {fileID: 1860645803}
+  m_Layer: 0
+  m_Name: Not_CharacterGroundedCondition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1860645802
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1860645801}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1635575639}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1860645803
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1860645801}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 87c09c96d8d54db085330027f556ca3c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _inverse: 1
+--- !u!1 &1989832166
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1989832167}
+  - component: {fileID: 1989832168}
+  m_Layer: 0
+  m_Name: Not_InputJumpCondition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1989832167
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1989832166}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 713103977}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1989832168
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1989832166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c723a9f1fc9a4dac920887b4fe00d45f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _inverse: 1
+--- !u!1 &2051104807
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2051104808}
+  - component: {fileID: 2051104809}
+  m_Layer: 0
+  m_Name: StateMachine
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2051104808
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2051104807}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 828343235}
+  - {fileID: 1841197487}
+  - {fileID: 1563130587}
+  - {fileID: 1375461305}
+  m_Father: {fileID: 6653959911160771794}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2051104809
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2051104807}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 92f00c1d7ba145ee96bb7b257b69daf7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _defaultState: {fileID: 4733411790445812980}
+  _debugCurrentState: {fileID: 0}
+--- !u!1 &2089516346
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2089516347}
+  - component: {fileID: 2089516348}
+  m_Layer: 0
+  m_Name: To_MovingState_Transition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2089516347
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2089516346}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 874001859}
+  m_Father: {fileID: 828343235}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2089516348
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2089516346}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25e5fedf33174467b668d49ac69cc614, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _targetState: {fileID: 3624877722083475732}
+--- !u!114 &3341179907149091245
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6653959911160771788}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6a918754be6642d2a376b2b90e0fec86, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 8
+  turnSmoothTime: 0.2
+  gravityMultiplier: 5
+  initialJumpForce: 10
+  jumpInputDuration: 0.4
+  gravityComebackMultiplier: 15
+  maxFallSpeed: 50
+  gravityDivider: 0.6
+  gravityContributionMultiplier: 0
+  isJumping: 0
+  jumpBeginTime: -Infinity
+  turnSmoothSpeed: 0
+  verticalMovement: 0
+  inputVector: {x: 0, y: 0, z: 0}
+  inputJump: 0
+  movementVector: {x: 0, y: 0, z: 0}
+--- !u!1001 &8217341045962577929
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 211818859182309264, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: inputReader
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 211818859182309264, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: gameplayCamera
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 211818859182309264, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240708, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240709, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_Name
+      value: Pig FSM Variant
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.62
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -15.776
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8355259865850373509, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 01456733de0da8a468ac0fd76cc40be8, type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0fa393e1e37bc9e4e829c25a9452bcd3, type: 3}
+--- !u!4 &6653959911160771794 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+    type: 3}
+  m_PrefabInstance: {fileID: 8217341045962577929}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &6653959911160771788 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3341179906418240709, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+    type: 3}
+  m_PrefabInstance: {fileID: 8217341045962577929}
+  m_PrefabAsset: {fileID: 0}

--- a/UOP1_Project/Assets/Prefabs/Pig FSM Variant.prefab.meta
+++ b/UOP1_Project/Assets/Prefabs/Pig FSM Variant.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 64339d0e2a3f0b541a7a824adeafc3d5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Characters/Protagonist.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/Protagonist.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using PlayerStateMachine;
+using UnityEngine;
 
 public class Protagonist : MonoBehaviour
 {
@@ -6,12 +7,14 @@ public class Protagonist : MonoBehaviour
     public Transform gameplayCamera;
 
     private Character charScript;
+    private CharacterMotor charMotorScript;
     private Vector2 previousMovementInput;
     private bool controlsEnabled = true;
 
     private void Awake()
     {
         charScript = GetComponent<Character>();
+        charMotorScript = GetComponent<CharacterMotor>();
     }
 
     //Adds listeners for events being triggered in the InputReader script
@@ -49,7 +52,8 @@ public class Protagonist : MonoBehaviour
         Vector3 adjustedMovement = cameraRight.normalized * previousMovementInput.x +
             cameraForward.normalized * previousMovementInput.y;
 
-        charScript.Move(Vector3.ClampMagnitude(adjustedMovement, 1f));
+        charScript?.Move(Vector3.ClampMagnitude(adjustedMovement, 1f));
+        charMotorScript?.Move(Vector3.ClampMagnitude(adjustedMovement, 1f));
     }
 
     //---- EVENT LISTENERS ----
@@ -61,11 +65,19 @@ public class Protagonist : MonoBehaviour
 
     private void OnJumpInitiated()
     {
-        if (controlsEnabled) charScript.Jump();
+        if (controlsEnabled)
+        {
+            charScript?.Jump();
+            charMotorScript?.Jump();
+        }
     }
 
     private void OnJumpCanceled()
     {
-        if (controlsEnabled) charScript.CancelJump();
+        if (controlsEnabled)
+        {
+            charScript?.CancelJump();
+            charMotorScript?.CancelJump();
+        }
     }
 }

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine.meta
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4924a28218d342cbb1c28d1330d0895b
+timeCreated: 1602790975

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions.meta
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9ddaccc7e91e4b66893301cc6e144df8
+timeCreated: 1602791395

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions/GravityStateAction.cs
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions/GravityStateAction.cs
@@ -1,0 +1,23 @@
+﻿using UnityEngine;
+
+namespace PlayerStateMachine.Actions
+{
+    public class GravityStateAction : PlayerStateAction
+    {
+        public override void OnUpdate(float deltaTime)
+        {
+            base.OnUpdate(deltaTime);
+            
+            _cm.verticalMovement += Physics.gravity.y * _cm.gravityMultiplier * deltaTime;
+            
+            //Apply the result and move the character in space
+            _cc.Move(_cm.verticalMovement * deltaTime * Vector3.up);
+        }
+
+        public override void OnExit()
+        {
+            base.OnExit();
+            _cm.verticalMovement = 0;
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions/GravityStateAction.cs.meta
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions/GravityStateAction.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 950c277402aa4059a06f96de71a830c5
+timeCreated: 1602791354

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions/IdleStateAction.cs
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions/IdleStateAction.cs
@@ -1,0 +1,13 @@
+﻿using UnityEngine;
+
+namespace PlayerStateMachine.Actions
+{
+    public class IdleStateAction : PlayerStateAction
+    {
+        public override void OnUpdate(float deltaTime)
+        {
+            base.OnUpdate(deltaTime);
+            _cc.Move(Vector3.down * deltaTime);
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions/IdleStateAction.cs.meta
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions/IdleStateAction.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0457bfefcd8b4b5ead1b57eff4f6450f
+timeCreated: 1602840799

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions/JampingStateAction.cs
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions/JampingStateAction.cs
@@ -1,0 +1,23 @@
+﻿using UnityEngine;
+
+namespace PlayerStateMachine.Actions
+{
+    public class JampingStateAction : PlayerStateAction
+    {
+        public override void OnUpdate(float deltaTime)
+        {
+            base.OnUpdate(deltaTime);
+
+            _cm.verticalMovement = _cm.initialJumpForce;
+            
+            //Apply the result and move the character in space
+            _cc.Move(_cm.verticalMovement * deltaTime * Vector3.up);
+        }
+
+        public override void OnExit()
+        {
+            base.OnExit();
+            _cm.inputJump = false;
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions/JampingStateAction.cs.meta
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions/JampingStateAction.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 64357be3bf86411493789ce4db3b71ee
+timeCreated: 1602791477

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions/MovingStateAction.cs
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions/MovingStateAction.cs
@@ -1,0 +1,31 @@
+﻿using UnityEngine;
+
+namespace PlayerStateMachine.Actions
+{
+    public class MovingStateAction : PlayerStateAction
+    {
+        [SerializeField] private float _speedMultiplier = 1f;
+        
+        public override void OnUpdate(float deltaTime)
+        {
+            base.OnUpdate(deltaTime);
+
+            _cm.movementVector = _cm.inputVector * _cm.speed * _speedMultiplier;
+            
+            //Apply the result and move the character in space
+            _cc.Move(_cm.movementVector * deltaTime);
+
+            //Rotate to the movement direction
+            _cm.movementVector.y = 0f;
+            if (_cm.movementVector.sqrMagnitude >= .02f)
+            {
+                float targetRotation = Mathf.Atan2(_cm.movementVector.x, _cm.movementVector.z) * Mathf.Rad2Deg;
+                _cm.transform.eulerAngles = Vector3.up * Mathf.SmoothDampAngle(
+                    transform.eulerAngles.y,
+                    targetRotation,
+                    ref _cm.turnSmoothSpeed,
+                    _cm.turnSmoothTime);
+            }
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions/MovingStateAction.cs.meta
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Actions/MovingStateAction.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0db2b50989d34e1f809a980b45beff32
+timeCreated: 1602840821

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/CharacterMotor.cs
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/CharacterMotor.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using UnityEngine;
+
+namespace PlayerStateMachine
+{
+    public class CharacterMotor : MonoBehaviour
+    {
+        private CharacterController characterController;
+
+        [Tooltip("Horizontal XZ plane speed multiplier")]
+        public float speed = 8f;
+
+        [Tooltip("Smoothing for rotating the character to their movement direction")]
+        public float turnSmoothTime = 0.2f;
+
+        [Tooltip("General multiplier for gravity (affects jump and freefall)")]
+        public float gravityMultiplier = 5f;
+
+        [Tooltip(
+            "The initial upwards push when pressing jump. This is injected into verticalMovement, and gradually cancelled by gravity")]
+        public float initialJumpForce = 10f;
+
+        [Tooltip("How long can the player hold the jump button")]
+        public float jumpInputDuration = .4f;
+
+        [Tooltip("Represents how fast gravityContributionMultiplier will go back to 1f. The higher, the faster")]
+        public float gravityComebackMultiplier = 15f;
+
+        [Tooltip("The maximum speed reached when falling (in units/frame)")]
+        public float maxFallSpeed = 50f;
+
+        [Tooltip(
+            "Each frame while jumping, gravity will be multiplied by this amount in an attempt to 'cancel it' (= jump higher)")]
+        public float gravityDivider = .6f;
+
+        public float
+            gravityContributionMultiplier =
+                0f; //The factor which determines how much gravity is affecting verticalMovement
+
+        public bool isJumping = false; //If true, a jump is in effect and the player is holding the jump button
+        public float jumpBeginTime = -Mathf.Infinity; //Time of the last jump
+
+        public float
+            turnSmoothSpeed; //Used by Mathf.SmoothDampAngle to smoothly rotate the character to their movement direction
+
+        public float
+            verticalMovement =
+                0f; //Represents how much a player will move vertically in a frame. Affected by gravity * gravityContributionMultiplier
+
+        public Vector3 inputVector; //Initial input horizontal movement (y == 0f)
+        public bool inputJump;
+        public Vector3 movementVector;
+        public bool IsGrounded => characterController.isGrounded;
+
+        private void Awake()
+        {
+            characterController = GetComponent<CharacterController>();
+        }
+
+        private void Update()
+        {
+        }
+
+        private void OnControllerColliderHit(ControllerColliderHit hit)
+        {
+            bool isMovingUpwards = verticalMovement > 0f;
+
+            if (isMovingUpwards)
+            {
+                // Making sure the collision is near the top of the head
+                float permittedDistance = characterController.radius / 2f;
+                float topPositionY = transform.position.y + characterController.height;
+                float distance = Mathf.Abs(hit.point.y - topPositionY);
+
+                if (distance <= permittedDistance)
+                {
+                    // Stopping any upwards movement
+                    // and having the player fall back down
+
+                    isJumping = false;
+                    gravityContributionMultiplier = 1f;
+
+                    verticalMovement = 0f;
+                }
+            }
+        }
+
+        //---- COMMANDS ISSUED BY OTHER SCRIPTS ----
+
+        public void Move(Vector3 movement)
+        {
+            inputVector = movement;
+        }
+
+        public void Jump()
+        {
+            inputJump = true;
+        }
+
+        public void CancelJump()
+        {
+            inputJump = false;
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/CharacterMotor.cs.meta
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/CharacterMotor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6a918754be6642d2a376b2b90e0fec86
+timeCreated: 1602851737

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions.meta
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d9dc0128436148df83a234876c33728f
+timeCreated: 1602843660

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions/CharacterGroundedCondition.cs
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions/CharacterGroundedCondition.cs
@@ -1,0 +1,17 @@
+﻿using StateMachines.Mono;
+using UnityEngine;
+
+namespace PlayerStateMachine.Conditions
+{
+    public class CharacterGroundedCondition : MonoCondition
+    {
+        private CharacterMotor _characterMotor;
+
+        private void Awake()
+        {
+            _characterMotor = GetComponentInParent<CharacterMotor>();
+        }
+
+        protected override bool Evaluate() => _characterMotor.IsGrounded;
+    }
+}

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions/CharacterGroundedCondition.cs.meta
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions/CharacterGroundedCondition.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 87c09c96d8d54db085330027f556ca3c
+timeCreated: 1602844006

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions/InputJumpCondition.cs
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions/InputJumpCondition.cs
@@ -1,0 +1,17 @@
+﻿using StateMachines.Mono;
+
+namespace PlayerStateMachine.Conditions
+{
+    public class InputJumpCondition : MonoCondition
+    {
+        private CharacterMotor _characterMotor;
+
+        private void Awake()
+        {
+            _characterMotor = GetComponentInParent<CharacterMotor>();
+        }
+        
+        protected override bool Evaluate() => _characterMotor.inputJump;
+
+    }
+}

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions/InputJumpCondition.cs.meta
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions/InputJumpCondition.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c723a9f1fc9a4dac920887b4fe00d45f
+timeCreated: 1602843680

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions/InputMoveCondition.cs
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions/InputMoveCondition.cs
@@ -1,0 +1,16 @@
+﻿using StateMachines.Mono;
+
+namespace PlayerStateMachine.Conditions
+{
+    public class InputMoveCondition : MonoCondition
+    {
+        private CharacterMotor _characterMotor;
+
+        protected override bool Evaluate() => _characterMotor.inputVector.magnitude > 0.01f;
+
+        private void Awake()
+        {
+            _characterMotor = GetComponentInParent<CharacterMotor>();
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions/InputMoveCondition.cs.meta
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions/InputMoveCondition.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dfa227e9f8e142dc9c2f427390e0c498
+timeCreated: 1602843829

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions/TimeInStateCondition.cs
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions/TimeInStateCondition.cs
@@ -1,0 +1,40 @@
+﻿using StateMachines;
+using StateMachines.Mono;
+using UnityEngine;
+
+namespace PlayerStateMachine.Conditions
+{
+    public class TimeInStateCondition : MonoCondition
+    {
+        [SerializeField] private MonoState _state = default;
+        [SerializeField] private float _time = 1f;
+
+        private float _entryTime;
+
+        private IStateMachine _stateMachine;
+        
+        private void Start()
+        {
+            _stateMachine = GetComponentInParent<IStateMachine>();
+            _stateMachine.StateChanged += OnStateChanged;
+        }
+
+        private void OnDestroy()
+        {
+            _stateMachine.StateChanged -= OnStateChanged;
+        }
+
+        private void OnStateChanged(IState state)
+        {
+            if ((MonoState) state == _state)
+            {
+                _entryTime = Time.time;
+            }
+        }
+
+        protected override bool Evaluate()
+        {
+            return Time.time > _entryTime + _time;
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions/TimeInStateCondition.cs.meta
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/Conditions/TimeInStateCondition.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 011792c5973c4efebcecf7f5149dbf48
+timeCreated: 1602847610

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/PlayerState.cs
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/PlayerState.cs
@@ -1,0 +1,27 @@
+﻿using StateMachines.Mono;
+using UnityEngine;
+
+namespace PlayerStateMachine
+{
+    public class PlayerState : MonoState
+    {
+        public virtual void Initialize(PlayerStateMachine context)
+        {
+            gameObject.SetActive(context.CurrentState == this);
+        }
+
+        public override void OnEnter()
+        {
+            Debug.Log($"Enter: {name}");
+            base.OnEnter();
+            gameObject.SetActive(true);
+        }
+
+        public override void OnExit()
+        {
+            Debug.Log($"Exit: {name}");
+            base.OnExit();
+            gameObject.SetActive(false);
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/PlayerState.cs.meta
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/PlayerState.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4b864070d50743e1a4ca5bf3d302d2b3
+timeCreated: 1603099299

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/PlayerStateAction.cs
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/PlayerStateAction.cs
@@ -1,0 +1,23 @@
+﻿using StateMachines.Mono;
+using UnityEngine;
+
+namespace PlayerStateMachine
+{
+    public abstract class PlayerStateAction : MonoStateAction
+    {
+        protected CharacterController _cc;
+        protected CharacterMotor _cm;
+
+        public void Awake()
+        {
+            _cm = GetComponentInParent<CharacterMotor>();
+            _cc = GetComponentInParent<CharacterController>();
+        }
+
+        public override void OnUpdate(float deltaTime)
+        {
+            base.OnUpdate(deltaTime);
+            Debug.Log($"Updating {name}.{GetType().Name}");
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/PlayerStateAction.cs.meta
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/PlayerStateAction.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 131b8458997a4f81844720ecbff77a5c
+timeCreated: 1602791017

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/PlayerStateMachine.cs
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/PlayerStateMachine.cs
@@ -1,0 +1,22 @@
+﻿using StateMachines.Mono;
+using UnityEngine;
+
+namespace PlayerStateMachine
+{
+    public class PlayerStateMachine : MonoStateMachine
+    {
+        [SerializeField] private PlayerState _debugCurrentState = default;
+        
+
+        private void Start()
+        {
+            PlayerState[] states = GetComponentsInChildren<PlayerState>();
+            foreach (var state in states)
+            {
+                state.Initialize(this);
+            }
+
+            _stateMachine.StateChanged += state => _debugCurrentState = (PlayerState) state;
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/PlayerStateMachine.cs.meta
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/PlayerStateMachine.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 92f00c1d7ba145ee96bb7b257b69daf7
+timeCreated: 1602790995

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/PlayerTransition.cs
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/PlayerTransition.cs
@@ -1,0 +1,30 @@
+﻿using StateMachines;
+using StateMachines.Mono;
+
+namespace PlayerStateMachine
+{
+    public class PlayerTransition : MonoTransition
+    {
+        private ICondition[] _conditions;
+
+        private void Awake()
+        {
+            _conditions = GetComponentsInChildren<ICondition>();
+        }
+
+        public override bool Evaluate()
+        {
+            foreach (var condition in _conditions)
+            {
+                if (!condition.Value)
+                    return false;
+            }
+            return true;
+        }
+
+        private void OnValidate()
+        {
+            name = $"To_{_targetState.name}_Transition";
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/PlayerStateMachine/PlayerTransition.cs.meta
+++ b/UOP1_Project/Assets/Scripts/PlayerStateMachine/PlayerTransition.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 25e5fedf33174467b668d49ac69cc614
+timeCreated: 1602841370

--- a/UOP1_Project/Assets/Scripts/StateMachines.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d4c32e4f54473c446af5a6c069bf14b9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/StateMachines/ICondition.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/ICondition.cs
@@ -1,0 +1,7 @@
+﻿namespace StateMachines
+{
+    public interface ICondition : IStateMachineEntity
+    {
+        bool Value { get; }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/ICondition.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/ICondition.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fb193fb274b2453a8ac92945c33f0d37
+timeCreated: 1602841281

--- a/UOP1_Project/Assets/Scripts/StateMachines/IState.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/IState.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections.Generic;
+
+namespace StateMachines
+{
+    public interface IState : IStateMachineEntity
+    {
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/IState.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/IState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b30ebb30d430294eb0d554ecd8361a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/StateMachines/IStateAction.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/IStateAction.cs
@@ -1,0 +1,6 @@
+﻿namespace StateMachines
+{
+    public interface IStateAction : IStateMachineEntity
+    {
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/IStateAction.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/IStateAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c148b57ce04ffe14f9d2ea56d3c47a09
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/StateMachines/IStateMachine.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/IStateMachine.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace StateMachines
+{
+    public interface IStateMachine
+    {
+        IState CurrentState { get; }
+
+        event Action<IState> StateChanged; 
+        
+        void ChangeState(IState state);
+
+        void OnUpdate(float deltaTime);
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/IStateMachine.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/IStateMachine.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ab900ef3124749aa964d4b50165d2709
+timeCreated: 1602785182

--- a/UOP1_Project/Assets/Scripts/StateMachines/IStateMachineEntity.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/IStateMachineEntity.cs
@@ -1,0 +1,13 @@
+﻿namespace StateMachines
+{
+    public interface IStateMachineEntity
+    {
+        void OnEnter();
+        
+        // Personally, I would like to name this methods without 'On' prefix,
+        // but Unity doesn't allow to use method with name 'Update' that has arguments. 
+        void OnUpdate(float deltaTime);
+        
+        void OnExit();
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/IStateMachineEntity.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/IStateMachineEntity.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7693eb13debb453a874bc1951e376e13
+timeCreated: 1603091477

--- a/UOP1_Project/Assets/Scripts/StateMachines/ITransition.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/ITransition.cs
@@ -1,0 +1,9 @@
+﻿namespace StateMachines
+{
+    public interface ITransition : IStateMachineEntity
+    {
+        IState TargetState { get; }
+        
+        bool Evaluate();
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/ITransition.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/ITransition.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bf1205e4c599453ab36633a42428d844
+timeCreated: 1602785438

--- a/UOP1_Project/Assets/Scripts/StateMachines/Mono.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Mono.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f8878d72eeee4070bbbbe99f3eb032fa
+timeCreated: 1602789610

--- a/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoCondition.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoCondition.cs
@@ -1,0 +1,26 @@
+﻿using UnityEngine;
+
+namespace StateMachines.Mono
+{
+    public abstract class MonoCondition : MonoBehaviour, ICondition
+    {
+        [SerializeField] private bool _inverse = false;
+
+        public bool Value => _inverse ? !Evaluate() : Evaluate();
+
+        public virtual void OnEnter() { }
+
+        public virtual void OnUpdate(float deltaTime) { }
+
+        public virtual void OnExit() { }
+        
+        protected abstract bool Evaluate();
+        
+        private void OnValidate()
+        {
+            name = GetType().Name;
+            if (_inverse)
+                name = "Not_" + name;
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoCondition.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoCondition.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 81d66c66b3a344d1b2dd8e4a3f60d9a8
+timeCreated: 1602841296

--- a/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoState.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoState.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace StateMachines.Mono
+{
+    public class MonoState : MonoBehaviour, IState
+    {
+        private List<IStateAction> _actions;
+        private List<ITransition> _transitions;
+        
+        protected virtual void Awake()
+        {
+            Debug.Log("MonoState.Awake()");
+            _transitions = new List<ITransition>();
+            GetComponentsInChildren<ITransition>(_transitions);
+            _actions = new List<IStateAction>();
+            GetComponentsInChildren<IStateAction>(_actions);
+        }
+
+        public virtual void OnEnter()
+        {
+            foreach (var action in _actions)
+                action.OnEnter();
+        }
+
+        public virtual void OnUpdate(float deltaTime)
+        {
+            foreach (var action in _actions)
+                action.OnUpdate(deltaTime);
+        }
+
+        public virtual void OnExit()
+        {
+            foreach (var action in _actions)
+                action.OnExit();
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoState.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoState.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d0bb8dea5e87445087200e2ddd75e88e
+timeCreated: 1602789746

--- a/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoStateAction.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoStateAction.cs
@@ -1,0 +1,13 @@
+﻿using UnityEngine;
+
+namespace StateMachines.Mono
+{
+    public abstract class MonoStateAction : MonoBehaviour, IStateAction
+    {
+        public virtual void OnEnter() { }
+
+        public virtual void OnUpdate(float deltaTime) { }
+
+        public virtual void OnExit() { }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoStateAction.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoStateAction.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 83ed5e4943f64a0a83590b97eb6c7303
+timeCreated: 1603091770

--- a/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoStateMachine.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoStateMachine.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace StateMachines.Mono
+{
+    public class MonoStateMachine : MonoBehaviour, IStateMachine
+    {
+        [SerializeField] private MonoState _defaultState = default;
+        protected IStateMachine _stateMachine;
+
+        public IStateMachine StateMachine => _stateMachine ?? (_stateMachine = new StateMachine(_defaultState, GetTransitionTable()));
+
+        protected virtual void Awake()
+        {
+        }
+
+        public IState CurrentState => _stateMachine.CurrentState;
+        
+        public event Action<IState> StateChanged
+        {
+            add => StateMachine.StateChanged += value;
+            remove => StateMachine.StateChanged -= value;
+        }
+
+        public void ChangeState(IState state)
+        {
+            StateMachine.ChangeState(state);
+        }
+
+        public void OnUpdate(float deltaTime)
+        {
+            StateMachine.OnUpdate(deltaTime);
+        }
+
+        private void Update()
+        {
+            OnUpdate(Time.deltaTime);
+        }
+
+        private IDictionary<IState, IEnumerable<ITransition>> GetTransitionTable()
+        {
+            List<MonoState> states = new List<MonoState>();
+            GetComponentsInChildren(states);
+            
+            IDictionary<IState, IEnumerable<ITransition>> table = new Dictionary<IState, IEnumerable<ITransition>>();
+            foreach (var state in states)
+            {
+                table.Add(state, state.GetComponentsInChildren<ITransition>());
+            }
+
+            return table;
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoStateMachine.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoStateMachine.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d677947abb1140e18235b2f354b9bdc5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: -500
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoTransition.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoTransition.cs
@@ -1,0 +1,19 @@
+﻿using UnityEngine;
+
+namespace StateMachines.Mono
+{
+    public abstract class MonoTransition : MonoBehaviour, ITransition
+    {
+        [SerializeField] protected MonoState _targetState = default;
+
+        public virtual IState TargetState => _targetState;
+        
+        public abstract bool Evaluate();
+        
+        public virtual void OnEnter() { }
+
+        public virtual void OnUpdate(float deltaTime) { }
+
+        public virtual void OnExit() { }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoTransition.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Mono/MonoTransition.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 663e8b5f91b643e9ac594ca3b747aae4
+timeCreated: 1602789810

--- a/UOP1_Project/Assets/Scripts/StateMachines/Plain.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Plain.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1f3092d4f3764c4e8c019e2d8904bcc2
+timeCreated: 1603092145

--- a/UOP1_Project/Assets/Scripts/StateMachines/Plain/Builder.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Plain/Builder.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: adb4ec9f5f5d40359b5802b26aba380d
+timeCreated: 1603093586

--- a/UOP1_Project/Assets/Scripts/StateMachines/Plain/Builder/Example.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Plain/Builder/Example.cs
@@ -1,0 +1,43 @@
+﻿namespace StateMachines.Plain.Builder
+{
+    public class Example
+    {
+        public void Execute()
+        {
+            // applies input to character
+            var moveAction = new PlainStateAction(null, null, null);
+            // applies input to character when it is in the air (falling or jumping)
+            var inAirMoveAction = new PlainStateAction(null, null, null);
+            // apples one time jump impulse to character
+            var jumpAction = new PlainStateAction(null, null, null);
+            // applies gravity force to character
+            var gravityAction = new PlainStateAction(null, null, null);
+            
+            var idleState = new PlainState(new IStateAction[]{ /* in idle do nothing */});
+            var runState = new PlainState(new []{moveAction, gravityAction});
+            var jumpState = new PlainState(new []{inAirMoveAction, jumpAction});
+            var fallState = new PlainState(new []{inAirMoveAction, gravityAction});
+            float speed = 10;
+            bool jump = true;
+            bool isGrounded = false;
+            IStateMachine stateMachine = new PlainStateMachineBuilder()
+                .Default(idleState)
+                
+                .From(idleState)
+                .To(runState, () => speed >= 10)
+                .To(jumpState, () => jump)
+                
+                .From(runState)
+                .To(idleState, () => speed <= 10)
+                .To(jumpState, () => jump)
+                .To(fallState, () => !isGrounded)
+                
+                .From(jumpState)
+                .To(fallState, () => true)
+                
+                .From(fallState)
+                .To(idleState, () => isGrounded)
+                .Build();
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/Plain/Builder/Example.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Plain/Builder/Example.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bd23825657e04ac385432d9f72e2444b
+timeCreated: 1603096959

--- a/UOP1_Project/Assets/Scripts/StateMachines/Plain/Builder/PlainStateMachineBuilder.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Plain/Builder/PlainStateMachineBuilder.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace StateMachines.Plain.Builder
+{
+    public class PlainStateMachineBuilder
+    {
+        private Dictionary<IState, List<ITransition>> _transitions = new Dictionary<IState, List<ITransition>>();
+        
+        private IState _currentState;
+        private IState _defaultState;
+        
+        public PlainStateMachineBuilder Default(IState state)
+        {
+            if (state == null)
+                throw new ArgumentNullException(nameof(state));
+            _defaultState = state;
+            return this;
+        }
+        
+        public PlainStateMachineBuilder From(IState state)
+        {
+            if (state == null)
+                throw new ArgumentNullException(nameof(state));
+            _currentState = state;
+            return this;
+        }
+        
+        public PlainStateMachineBuilder To(IState state, Func<bool> condition)
+        {
+            if (_currentState == null)
+                throw new Exception("Invalid builder state. Call From<T>() before using To<T>()");
+            if (!_transitions.ContainsKey(_currentState))
+                _transitions.Add(_currentState, new List<ITransition>());
+            var transition = new PlainTransition(_currentState, condition);
+            _transitions[state].Add(transition);
+            return this;
+        }
+        
+        
+        public IStateMachine Build()
+        {
+            IDictionary<IState, IEnumerable<ITransition>> transitionsMap = new Dictionary<IState, IEnumerable<ITransition>>();
+            foreach (var pair in _transitions)
+            {
+                transitionsMap.Add(pair.Key, pair.Value);
+            }
+            return new StateMachine(_defaultState, transitionsMap);
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/Plain/Builder/PlainStateMachineBuilder.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Plain/Builder/PlainStateMachineBuilder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4ee02e4ae0594bec9df8c0167103f77d
+timeCreated: 1603093716

--- a/UOP1_Project/Assets/Scripts/StateMachines/Plain/PlainState.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Plain/PlainState.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace StateMachines.Plain
+{
+    public class PlainState : IState
+    {
+        private readonly IEnumerable<IStateAction> _actions;
+
+        public PlainState(IEnumerable<IStateAction> actions)
+        {
+            _actions = actions;
+        }
+
+        public virtual void OnEnter()
+        {
+            foreach (var action in _actions)
+                action.OnEnter();
+        }
+
+        public virtual void OnUpdate(float deltaTime)
+        {
+            foreach (var action in _actions)
+                action.OnUpdate(deltaTime);
+        }
+
+        public virtual void OnExit()
+        {
+            foreach (var action in _actions)
+                action.OnExit();
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/Plain/PlainState.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Plain/PlainState.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: df7ce2eaf3144db7be16876d8ab8363d
+timeCreated: 1603092156

--- a/UOP1_Project/Assets/Scripts/StateMachines/Plain/PlainStateAction.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Plain/PlainStateAction.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace StateMachines.Plain
+{
+    public class PlainStateAction : IStateAction
+    {
+        private readonly Action _enter;
+        private readonly Action<float> _update;
+        private readonly Action _exit;
+
+        public PlainStateAction(Action enter, Action<float> update, Action exit)
+        {
+            _enter = enter;
+            _update = update;
+            _exit = exit;
+        }
+
+        public void OnEnter()
+        {
+            _enter?.Invoke();
+        }
+
+        public void OnUpdate(float deltaTime)
+        {
+            _update?.Invoke(deltaTime);
+        }
+
+        public void OnExit()
+        {
+            _exit?.Invoke();
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/Plain/PlainStateAction.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Plain/PlainStateAction.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 483a7dc8f018462f9c4673874e41cc89
+timeCreated: 1603092381

--- a/UOP1_Project/Assets/Scripts/StateMachines/Plain/PlainTransition.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Plain/PlainTransition.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace StateMachines.Plain
+{
+    public class PlainTransition : ITransition
+    {
+        private readonly IState _toState;
+        private readonly Func<bool> _func;
+
+        public PlainTransition(IState toState, Func<bool> func)
+        {
+            _toState = toState;
+            _func = func;
+        }
+
+        public IState TargetState => _toState;
+
+        public virtual bool Evaluate()
+        {
+            return _func.Invoke();
+        }
+
+        public void OnEnter() { }
+
+        public void OnUpdate(float deltaTime) { }
+
+        public void OnExit() { }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/Plain/PlainTransition.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Plain/PlainTransition.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3ab07e7ff5354454990afa29776282c5
+timeCreated: 1603092566

--- a/UOP1_Project/Assets/Scripts/StateMachines/Scriptable.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Scriptable.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8e4a23058f714825a21c5a39f42a47b9
+timeCreated: 1602790256

--- a/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableCondition.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableCondition.cs
@@ -1,0 +1,15 @@
+﻿using UnityEngine;
+
+namespace StateMachines.Scriptable
+{
+    public abstract class ScriptableCondition : ScriptableObject, ICondition
+    {
+        public abstract bool Value { get; }
+        
+        public virtual void OnEnter() { }
+
+        public virtual void OnUpdate(float deltaTime) { }
+
+        public virtual void OnExit() { }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableCondition.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableCondition.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 433d763007a246f2a06fabf86dba0aff
+timeCreated: 1602790297

--- a/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableState.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableState.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace StateMachines.Scriptable
+{
+    public abstract class ScriptableState : ScriptableObject, IState
+    {
+        [SerializeField] private List<ScriptableStateAction> _actions;
+
+        public virtual void OnEnter()
+        {
+            foreach (var action in _actions)
+                action.OnEnter();
+        }
+
+        public virtual void OnUpdate(float deltaTime)
+        {
+            foreach (var action in _actions)
+                action.OnUpdate(deltaTime);
+        }
+
+        public virtual void OnExit()
+        {
+            foreach (var action in _actions)
+                action.OnExit();
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableState.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableState.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fb1da1d662a94e8ab299a83e24d8e931
+timeCreated: 1602790266

--- a/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableStateAction.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableStateAction.cs
@@ -1,0 +1,13 @@
+﻿using UnityEngine;
+
+namespace StateMachines.Scriptable
+{
+    public abstract class ScriptableStateAction : ScriptableObject, IStateMachineEntity
+    {
+        public virtual void OnEnter() { }
+
+        public virtual void OnUpdate(float deltaTime) { }
+
+        public virtual void OnExit() { }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableStateAction.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableStateAction.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7995a8ac05f94ba49ec75983dfeddec3
+timeCreated: 1603091671

--- a/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableStateMachine.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableStateMachine.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using UnityEngine;
+
+namespace StateMachines.Scriptable
+{
+    public abstract class ScriptableStateMachine : ScriptableObject, IStateMachine
+    {
+        [SerializeField] private ScriptableState _defaultState = default;
+        [SerializeField] private ScriptableTransitionTable _scriptableTransitionTable = default;
+
+        protected IStateMachine _stateMachine;
+
+        protected virtual void Awake()
+        {
+            _stateMachine = new StateMachine(_defaultState, _scriptableTransitionTable.Get());
+        }
+
+        public virtual IState CurrentState => _stateMachine.CurrentState;
+
+        public event Action<IState> StateChanged;
+
+        public virtual void ChangeState(IState state)
+        {
+            _stateMachine.ChangeState(state);
+        }
+
+        public virtual void OnUpdate(float deltaTime)
+        {
+            _stateMachine.OnUpdate(deltaTime);
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableStateMachine.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableStateMachine.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0e105ca3f4f64ea78ad12c14bc913308
+timeCreated: 1602790344

--- a/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableTransitionTable.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableTransitionTable.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace StateMachines.Scriptable
+{
+    public class ScriptableTransitionTable : ScriptableObject
+    {
+        [SerializeField] private List<SerializableTransition> _transitions;
+        
+        [System.Serializable]
+        private class SerializableTransition
+        {
+            public ScriptableState fromState;
+            public ScriptableState toState;
+            public List<ScriptableCondition> conditions;
+        }
+
+        private class Transition : ITransition
+        {
+            private readonly IState _targetState;
+            private readonly IEnumerable<ICondition> _conditions;
+
+            public Transition(IState targetState, IEnumerable<ICondition> conditions)
+            {
+                _targetState = targetState;
+                _conditions = conditions;
+            }
+
+            public IState TargetState => _targetState;
+            
+            public bool Evaluate()
+            {
+                return _conditions.All(c => c.Value);
+            }
+
+            public void OnEnter()
+            {
+                foreach (var condition in _conditions)
+                    condition.OnEnter();
+            }
+
+            public void OnUpdate(float deltaTime)
+            {
+                foreach (var condition in _conditions)
+                    condition.OnUpdate(deltaTime);
+            }
+
+            public void OnExit()
+            {
+                foreach (var condition in _conditions)
+                    condition.OnExit();
+            }
+        }
+
+        public IDictionary<IState, IEnumerable<ITransition>> Get()
+        {
+            Dictionary<IState, List<ITransition>> dictionary = new Dictionary<IState, List<ITransition>>();
+            foreach (var transition in _transitions)
+            {
+                if (!dictionary.ContainsKey(transition.fromState))
+                    dictionary.Add(transition.fromState, new List<ITransition>());
+                dictionary[transition.fromState].Add(new Transition(transition.toState, transition.conditions));
+            }
+            
+            IDictionary<IState, IEnumerable<ITransition>> result = new Dictionary<IState, IEnumerable<ITransition>>();
+            foreach (var pair in dictionary)
+            {
+                result.Add(pair.Key, pair.Value);
+            }
+            return result;
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableTransitionTable.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/Scriptable/ScriptableTransitionTable.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e713eaa97b5a4850b302cbdc3566c82f
+timeCreated: 1603094728

--- a/UOP1_Project/Assets/Scripts/StateMachines/StateMachine.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachines/StateMachine.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace StateMachines
+{
+    public class StateMachine : IStateMachine
+    {
+        public IState CurrentState => _currentState;
+
+        private IState _currentState;
+        private readonly IDictionary<IState, IEnumerable<ITransition>> _transitionsMap;
+
+        public event Action<IState> StateChanged; 
+        
+        public StateMachine(IState state, IDictionary<IState, IEnumerable<ITransition>> transitionsMap)
+        {
+            _currentState = state;
+            _transitionsMap = transitionsMap;
+            _currentState.OnEnter();
+        }
+
+        public void ChangeState(IState state)
+        {
+            if (state == null)
+                throw new ArgumentNullException(nameof(state));
+            _currentState?.OnExit();
+            _currentState = state;
+            _currentState?.OnEnter();
+            OnStateChanged();
+        }
+
+        public void OnUpdate(float deltaTime)
+        {
+            IEnumerable<ITransition> transitions = _transitionsMap[CurrentState];
+            IState nextState = null;
+            foreach (var transition in transitions)
+            {
+                if (transition.Evaluate())
+                {
+                    nextState = transition.TargetState;
+                    Debug.Log($"Transiting to {nextState} because of {transition}", transition as Object);
+                    break;
+                }
+            }
+            if (nextState != null)
+                ChangeState(nextState);
+            
+            _currentState?.OnUpdate(deltaTime);
+        }
+
+        protected virtual void OnStateChanged()
+        {
+            StateChanged?.Invoke(CurrentState);
+        }
+    }
+}

--- a/UOP1_Project/Assets/Scripts/StateMachines/StateMachine.cs.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachines/StateMachine.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 56b5b42e54f14a9aa4bdb581d17dcecb
+timeCreated: 1602785049

--- a/UOP1_Project/Assets/Tests/PlayerFSM.meta
+++ b/UOP1_Project/Assets/Tests/PlayerFSM.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ac1275b03c383824fa53831c2b6cfd32
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Tests/PlayerFSM/CharControllerFSM.unity
+++ b/UOP1_Project/Assets/Tests/PlayerFSM/CharControllerFSM.unity
@@ -1,0 +1,3459 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.32489324, g: 0.36377177, b: 0.46226418, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 1
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 1
+    m_BakeBackend: 2
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 1
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 2
+    m_PVRDenoiserTypeIndirect: 2
+    m_PVRDenoiserTypeAO: 2
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 0
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 112000000, guid: 9b538bdb729a2884e9bdd7c1c2cfe4fa,
+    type: 2}
+  m_UseShadowmask: 0
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &85035896
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6653959911160771788, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_Name
+      value: Pig FSM Variant
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771788, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_Icon
+      value: 
+      objectReference: {fileID: 419385456094870383, guid: 0000000000000000d000000000000000,
+        type: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.54
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.00000023841858
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -15.784428
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6653959911160771794, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8140630184192386969, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: inputReader
+      value: 
+      objectReference: {fileID: 1724036687}
+    - target: {fileID: 8140630184192386969, guid: 64339d0e2a3f0b541a7a824adeafc3d5,
+        type: 3}
+      propertyPath: gameplayCamera
+      value: 
+      objectReference: {fileID: 1961065790}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 64339d0e2a3f0b541a7a824adeafc3d5, type: 3}
+--- !u!1 &135922103
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 135922105}
+  - component: {fileID: 135922104}
+  - component: {fileID: 135922106}
+  m_Layer: 0
+  m_Name: CM vcam1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &135922104
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 135922103}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_Lens:
+    FieldOfView: 60
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    LensShift: {x: 0, y: 0}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 2020721999}
+--- !u!4 &135922105
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 135922103}
+  m_LocalRotation: {x: 0.24395259, y: 0, z: 0, w: 0.9697872}
+  m_LocalPosition: {x: 0.62, y: 5.737, z: -25.886}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2020721999}
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &135922106
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 135922103}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e501d18bb52cf8c40b1853ca4904654f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_CollideAgainst:
+    serializedVersion: 2
+    m_Bits: 1
+  m_IgnoreTag: 
+  m_TransparentLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_MinimumDistanceFromTarget: 0.1
+  m_AvoidObstacles: 1
+  m_DistanceLimit: 0
+  m_MinimumOcclusionTime: 0
+  m_CameraRadius: 0.1
+  m_Strategy: 1
+  m_MaximumEffort: 4
+  m_SmoothingTime: 0
+  m_Damping: 0
+  m_DampingWhenOccluded: 0
+  m_OptimalTargetDistance: 0
+--- !u!1 &233317031
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 233317033}
+  - component: {fileID: 233317032}
+  m_Layer: 0
+  m_Name: BottomRig
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &233317032
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 233317031}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  - Header
+  - Extensions
+  - m_Priority
+  - m_Transitions
+  - m_Follow
+  - m_StandbyUpdate
+  - m_Lens
+  m_LockStageInInspector: 00000000
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_Lens:
+    FieldOfView: 40
+    OrthographicSize: 10
+    NearClipPlane: 0.1
+    FarClipPlane: 2000
+    Dutch: 0
+    LensShift: {x: 0, y: 0}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 2018663599}
+--- !u!4 &233317033
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 233317031}
+  m_LocalRotation: {x: 0.18994758, y: -0.2052703, z: 0.040647592, w: 0.959235}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2018663599}
+  m_Father: {fileID: 1502793902}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &308908774
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 308908778}
+  - component: {fileID: 308908777}
+  - component: {fileID: 308908776}
+  - component: {fileID: 308908775}
+  m_Layer: 0
+  m_Name: Cube (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!65 &308908775
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 308908774}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &308908776
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 308908774}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &308908777
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 308908774}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &308908778
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 308908774}
+  m_LocalRotation: {x: -0.06795407, y: 0.21925889, z: -0.15772013, w: 0.9604333}
+  m_LocalPosition: {x: 6.84, y: 0.38725814, z: 1.01}
+  m_LocalScale: {x: 5.7737727, y: 1.8967, z: 4.9019}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 14
+  m_LocalEulerAnglesHint: {x: -3.5180001, y: 26.323002, z: -19.474}
+--- !u!1001 &321485602
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 211818859182309264, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: inputReader
+      value: 
+      objectReference: {fileID: 1724036687}
+    - target: {fileID: 211818859182309264, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: gameplayCamera
+      value: 
+      objectReference: {fileID: 1961065790}
+    - target: {fileID: 3341179906418240709, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_Name
+      value: Pig (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -15.82
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 29
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341179906418240731, guid: 0fa393e1e37bc9e4e829c25a9452bcd3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0fa393e1e37bc9e4e829c25a9452bcd3, type: 3}
+--- !u!1 &353533559
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 353533563}
+  - component: {fileID: 353533562}
+  - component: {fileID: 353533561}
+  - component: {fileID: 353533560}
+  m_Layer: 0
+  m_Name: Cube (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!65 &353533560
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 353533559}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &353533561
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 353533559}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &353533562
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 353533559}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &353533563
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 353533559}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -13.85, y: 0.19, z: -9.68}
+  m_LocalScale: {x: 4.8320527, y: 1, z: 4.9019}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &358843509
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 358843513}
+  - component: {fileID: 358843512}
+  - component: {fileID: 358843511}
+  - component: {fileID: 358843510}
+  m_Layer: 0
+  m_Name: Cube (7)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!65 &358843510
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 358843509}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &358843511
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 358843509}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &358843512
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 358843509}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &358843513
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 358843509}
+  m_LocalRotation: {x: -0, y: 0.70710576, z: -0, w: 0.70710784}
+  m_LocalPosition: {x: 6.9, y: 0.1, z: 6.414}
+  m_LocalScale: {x: 7.8816566, y: 6.5043144, z: 2.0265193}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 25
+  m_LocalEulerAnglesHint: {x: 0, y: 90.00001, z: 0}
+--- !u!1001 &393067907
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.026470782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.19267608
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.046884477
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.97978425
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -4.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 22.086
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 4.696
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.31
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 7500093032234365829, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_Name
+      value: TreeRound (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fe3004506b4c6cd478eb2cca639b3713, type: 3}
+--- !u!1 &395747637
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 395747638}
+  m_Layer: 0
+  m_Name: ---------  ENVIRONMENT --------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &395747638
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 395747637}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &526256409
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 526256411}
+  - component: {fileID: 526256410}
+  m_Layer: 0
+  m_Name: CameraManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &526256410
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 526256409}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 085156cba0e34b540aeddafe12d1e2f1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  inputReader: {fileID: 1724036687}
+  freeLookVCam: {fileID: 1502793901}
+  cameraSensitivity: 7
+--- !u!4 &526256411
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 526256409}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &695792052
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 695792053}
+  m_Layer: 0
+  m_Name: ---------  MANAGERS --------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &695792053
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 695792052}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &716155109
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 716155112}
+  - component: {fileID: 716155111}
+  - component: {fileID: 716155110}
+  m_Layer: 0
+  m_Name: Terrain
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!154 &716155110
+TerrainCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 716155109}
+  m_Material: {fileID: 0}
+  m_Enabled: 1
+  m_TerrainData: {fileID: 15600000, guid: d2f9219a4ab0e2a4cb78fd299208c3e5, type: 2}
+  m_EnableTreeColliders: 1
+--- !u!218 &716155111
+Terrain:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 716155109}
+  m_Enabled: 1
+  serializedVersion: 6
+  m_TerrainData: {fileID: 15600000, guid: d2f9219a4ab0e2a4cb78fd299208c3e5, type: 2}
+  m_TreeDistance: 5000
+  m_TreeBillboardDistance: 50
+  m_TreeCrossFadeLength: 5
+  m_TreeMaximumFullLODCount: 50
+  m_DetailObjectDistance: 80
+  m_DetailObjectDensity: 1
+  m_HeightmapPixelError: 5
+  m_SplatMapDistance: 1000
+  m_HeightmapMaximumLOD: 0
+  m_ShadowCastingMode: 2
+  m_DrawHeightmap: 1
+  m_DrawInstanced: 0
+  m_DrawTreesAndFoliage: 1
+  m_ReflectionProbeUsage: 1
+  m_MaterialTemplate: {fileID: 2100000, guid: 594ea882c5a793440b60ff72d896021e, type: 2}
+  m_BakeLightProbesForTrees: 1
+  m_PreserveTreePrototypeLayers: 0
+  m_DeringLightProbesForTrees: 1
+  m_ScaleInLightmap: 0.128
+  m_LightmapParameters: {fileID: 15203, guid: 0000000000000000f000000000000000, type: 0}
+  m_GroupingID: 0
+  m_RenderingLayerMask: 1
+  m_AllowAutoConnect: 1
+--- !u!4 &716155112
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 716155109}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -35.12, y: 0, z: -49.42}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &802198071
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 75542900160593349, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 364731123117828817, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Name
+      value: SmallBuilding (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 364731123117828817, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Icon
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.21
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 16.94
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.02212481
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.34912503
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.0073698456
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.936786
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -2.6710002
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 40.881
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -0.094000004
+      objectReference: {fileID: 0}
+    - target: {fileID: 1393031842072757971, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 1550431228679747100, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 4062301303505632421, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 4486111335160271541, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 5635836180088380747, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 5884884705227387567, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 6220766699795776869, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1ebb75c12ef91014e94524019e01192d, type: 3}
+--- !u!1 &804472773
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 804472775}
+  - component: {fileID: 804472774}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &804472774
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 804472773}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 1
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &804472775
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 804472773}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 50, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &826602623
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 826602624}
+  m_Layer: 0
+  m_Name: ---------  LIGHTING --------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &826602624
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 826602623}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &955504286
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 955504290}
+  - component: {fileID: 955504289}
+  - component: {fileID: 955504288}
+  - component: {fileID: 955504287}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!65 &955504287
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 955504286}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &955504288
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 955504286}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &955504289
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 955504286}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &955504290
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 955504286}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.94, y: 0.1, z: -9.68}
+  m_LocalScale: {x: 4.66705, y: 1, z: 4.9019}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &982338980
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 982338984}
+  - component: {fileID: 982338983}
+  - component: {fileID: 982338982}
+  - component: {fileID: 982338981}
+  m_Layer: 0
+  m_Name: Cube (8)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &982338981
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 982338980}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &982338982
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 982338980}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &982338983
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 982338980}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &982338984
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 982338980}
+  m_LocalRotation: {x: -0, y: -0, z: 0.10677427, w: 0.9942833}
+  m_LocalPosition: {x: -3.76, y: 2.682, z: 0.74}
+  m_LocalScale: {x: 4.66705, y: 1, z: 4.9019}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 26
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 12.259001}
+--- !u!1001 &991981654
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6584654389537195281, guid: 93e54cb6384095e49ba2e14fb5adae35,
+        type: 3}
+      propertyPath: inputReader
+      value: 
+      objectReference: {fileID: 1724036687}
+    - target: {fileID: 6584654389537195281, guid: 93e54cb6384095e49ba2e14fb5adae35,
+        type: 3}
+      propertyPath: gameplayCamera
+      value: 
+      objectReference: {fileID: 1961065790}
+    - target: {fileID: 8633309272373302852, guid: 93e54cb6384095e49ba2e14fb5adae35,
+        type: 3}
+      propertyPath: m_Name
+      value: Pig FSM DoubleJump Variant
+      objectReference: {fileID: 0}
+    - target: {fileID: 8633309272373302852, guid: 93e54cb6384095e49ba2e14fb5adae35,
+        type: 3}
+      propertyPath: m_Icon
+      value: 
+      objectReference: {fileID: -1412012063857583412, guid: 0000000000000000d000000000000000,
+        type: 0}
+    - target: {fileID: 8633309272373302852, guid: 93e54cb6384095e49ba2e14fb5adae35,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8633309272373302874, guid: 93e54cb6384095e49ba2e14fb5adae35,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.19
+      objectReference: {fileID: 0}
+    - target: {fileID: 8633309272373302874, guid: 93e54cb6384095e49ba2e14fb5adae35,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 8633309272373302874, guid: 93e54cb6384095e49ba2e14fb5adae35,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -15.776
+      objectReference: {fileID: 0}
+    - target: {fileID: 8633309272373302874, guid: 93e54cb6384095e49ba2e14fb5adae35,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8633309272373302874, guid: 93e54cb6384095e49ba2e14fb5adae35,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8633309272373302874, guid: 93e54cb6384095e49ba2e14fb5adae35,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8633309272373302874, guid: 93e54cb6384095e49ba2e14fb5adae35,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8633309272373302874, guid: 93e54cb6384095e49ba2e14fb5adae35,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 31
+      objectReference: {fileID: 0}
+    - target: {fileID: 8633309272373302874, guid: 93e54cb6384095e49ba2e14fb5adae35,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8633309272373302874, guid: 93e54cb6384095e49ba2e14fb5adae35,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8633309272373302874, guid: 93e54cb6384095e49ba2e14fb5adae35,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 93e54cb6384095e49ba2e14fb5adae35, type: 3}
+--- !u!1 &1057381576
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1057381580}
+  - component: {fileID: 1057381579}
+  - component: {fileID: 1057381578}
+  - component: {fileID: 1057381577}
+  m_Layer: 0
+  m_Name: Cube (6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!65 &1057381577
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057381576}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1057381578
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057381576}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1057381579
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057381576}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1057381580
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057381576}
+  m_LocalRotation: {x: -0, y: -0.29849088, z: -0, w: 0.95441246}
+  m_LocalPosition: {x: -6.72, y: 0.1, z: 7.87}
+  m_LocalScale: {x: 6.068361, y: 6.5043144, z: 0.65092325}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 24
+  m_LocalEulerAnglesHint: {x: 0, y: -34.734, z: 0}
+--- !u!1 &1069143686
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1069143687}
+  m_Layer: 0
+  m_Name: ---------  CAMERA WORK --------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1069143687
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1069143686}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1069947040
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1069947042}
+  - component: {fileID: 1069947041}
+  m_Layer: 0
+  m_Name: TopRig
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1069947041
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1069947040}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  - Header
+  - Extensions
+  - m_Priority
+  - m_Transitions
+  - m_Follow
+  - m_StandbyUpdate
+  - m_Lens
+  m_LockStageInInspector: 00000000
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_Lens:
+    FieldOfView: 40
+    OrthographicSize: 10
+    NearClipPlane: 0.1
+    FarClipPlane: 2000
+    Dutch: 0
+    LensShift: {x: 0, y: 0}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 2084548122}
+--- !u!4 &1069947042
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1069947040}
+  m_LocalRotation: {x: 0.18492083, y: -0.20548035, z: 0.0395719, w: 0.96021676}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2084548122}
+  m_Father: {fileID: 1502793902}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1259640866
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 75542900160593349, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 364731123117828817, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Name
+      value: SmallBuilding (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 364731123117828817, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Icon
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -16.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.49
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.62
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.0024269412
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.07057686
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.034281094
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.99691415
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0.555
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -8.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 3.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1393031842072757971, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 1550431228679747100, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 4062301303505632421, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 4486111335160271541, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 5635836180088380747, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 5884884705227387567, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 6220766699795776869, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1ebb75c12ef91014e94524019e01192d, type: 3}
+--- !u!1 &1259640867 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 364731123117828817, guid: 1ebb75c12ef91014e94524019e01192d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1259640866}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &1259640868
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259640867}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 4.9118204, y: 4.1104574, z: 4.8376255}
+  m_Center: {x: 0.3429799, y: 2.037253, z: 0.10196686}
+--- !u!1 &1303725911
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1303725915}
+  - component: {fileID: 1303725914}
+  - component: {fileID: 1303725913}
+  - component: {fileID: 1303725912}
+  m_Layer: 0
+  m_Name: Cube (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!65 &1303725912
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1303725911}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1303725913
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1303725911}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1303725914
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1303725911}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1303725915
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1303725911}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -7.3600006, y: 1, z: -9.68}
+  m_LocalScale: {x: 9.785265, y: 1.1941, z: 1.4703052}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1424964852
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1424964856}
+  - component: {fileID: 1424964855}
+  - component: {fileID: 1424964854}
+  - component: {fileID: 1424964853}
+  m_Layer: 0
+  m_Name: Cube (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!65 &1424964853
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1424964852}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1424964854
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1424964852}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1424964855
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1424964852}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1424964856
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1424964852}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.46, y: 0.1, z: 9.35}
+  m_LocalScale: {x: 11.689932, y: 6.5043144, z: 2.0265193}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 23
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1502793900
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1502793902}
+  - component: {fileID: 1502793901}
+  m_Layer: 0
+  m_Name: CM FreeLook1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1502793901
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1502793900}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 319d2fe34a804e245819465c9505ea59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_CommonLens: 1
+  m_Lens:
+    FieldOfView: 40
+    OrthographicSize: 10
+    NearClipPlane: 0.1
+    FarClipPlane: 2000
+    Dutch: 0
+    LensShift: {x: 0, y: 0}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_YAxis:
+    Value: 0.5
+    m_SpeedMode: 0
+    m_MaxSpeed: 80
+    m_AccelTime: 0.5
+    m_DecelTime: 0.1
+    m_InputAxisName: 
+    m_InputAxisValue: 0
+    m_InvertInput: 1
+    m_MinValue: 0
+    m_MaxValue: 1
+    m_Wrap: 0
+    m_Recentering:
+      m_enabled: 0
+      m_WaitTime: 1
+      m_RecenteringTime: 2
+      m_LegacyHeadingDefinition: -1
+      m_LegacyVelocityFilterStrength: -1
+  m_YAxisRecentering:
+    m_enabled: 1
+    m_WaitTime: 2
+    m_RecenteringTime: 3
+    m_LegacyHeadingDefinition: -1
+    m_LegacyVelocityFilterStrength: -1
+  m_XAxis:
+    Value: 0
+    m_SpeedMode: 0
+    m_MaxSpeed: 8000
+    m_AccelTime: 0.5
+    m_DecelTime: 0.1
+    m_InputAxisName: 
+    m_InputAxisValue: 0
+    m_InvertInput: 0
+    m_MinValue: -180
+    m_MaxValue: 180
+    m_Wrap: 1
+    m_Recentering:
+      m_enabled: 0
+      m_WaitTime: 1
+      m_RecenteringTime: 2
+      m_LegacyHeadingDefinition: -1
+      m_LegacyVelocityFilterStrength: -1
+  m_Heading:
+    m_Definition: 2
+    m_VelocityFilterStrength: 4
+    m_Bias: 0
+  m_RecenterToTargetHeading:
+    m_enabled: 0
+    m_WaitTime: 1
+    m_RecenteringTime: 2
+    m_LegacyHeadingDefinition: -1
+    m_LegacyVelocityFilterStrength: -1
+  m_BindingMode: 5
+  m_SplineCurvature: 0.2
+  m_Orbits:
+  - m_Height: 10
+    m_Radius: 16.88
+  - m_Height: 6
+    m_Radius: 10
+  - m_Height: 1.5
+    m_Radius: 4.5
+  m_LegacyHeadingBias: 3.4028235e+38
+  m_Rigs:
+  - {fileID: 1069947041}
+  - {fileID: 2049112420}
+  - {fileID: 233317032}
+--- !u!4 &1502793902
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1502793900}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.712467, y: 6.03, z: -24.900238}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1069947042}
+  - {fileID: 2049112421}
+  - {fileID: 233317033}
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1523164311
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1523164312}
+  m_Layer: 0
+  m_Name: ---------  GAMEPLAY --------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1523164312
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1523164311}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 28
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1559010558
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1559010562}
+  - component: {fileID: 1559010561}
+  - component: {fileID: 1559010560}
+  - component: {fileID: 1559010559}
+  m_Layer: 0
+  m_Name: Cube (9)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1559010559
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1559010558}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1559010560
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1559010558}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1559010561
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1559010558}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1559010562
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1559010558}
+  m_LocalRotation: {x: -0, y: -0, z: 0.10677427, w: 0.9942833}
+  m_LocalPosition: {x: 3.8, y: -0.08, z: -2.92}
+  m_LocalScale: {x: 4.66705, y: 1, z: 4.9019}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 27
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 12.259001}
+--- !u!1 &1567022179
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1567022183}
+  - component: {fileID: 1567022182}
+  - component: {fileID: 1567022181}
+  - component: {fileID: 1567022180}
+  m_Layer: 0
+  m_Name: Cube (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!65 &1567022180
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1567022179}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1567022181
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1567022179}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1567022182
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1567022179}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1567022183
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1567022179}
+  m_LocalRotation: {x: 0.026077801, y: 0.22806217, z: 0.24232899, w: 0.9426475}
+  m_LocalPosition: {x: 2.8078, y: 0.051378, z: 3.0279}
+  m_LocalScale: {x: 5.7737727, y: 1.8967, z: 4.9019}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 16
+  m_LocalEulerAnglesHint: {x: -3.5180001, y: 26.324001, z: 28.011002}
+--- !u!1 &1724036686
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1724036688}
+  - component: {fileID: 1724036687}
+  m_Layer: 0
+  m_Name: InputReader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1724036687
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1724036686}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 143f1e276019d54448855eb41708d190, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1724036688
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1724036686}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1809933188
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 75542900160593349, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 364731123117828817, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Name
+      value: SmallBuilding (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 364731123117828817, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Icon
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.39
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1393031842072757971, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 1550431228679747100, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 4062301303505632421, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 4486111335160271541, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 5635836180088380747, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 5884884705227387567, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 6220766699795776869, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1ebb75c12ef91014e94524019e01192d, type: 3}
+--- !u!1001 &1887993772
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 75542900160593349, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 364731123117828817, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Name
+      value: SmallBuilding (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 364731123117828817, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Icon
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.16
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.19
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.12
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.02212481
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.34912503
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.0073698456
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.936786
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -2.6710002
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 40.881
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -0.094000004
+      objectReference: {fileID: 0}
+    - target: {fileID: 1393031842072757971, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 1550431228679747100, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 4062301303505632421, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 4486111335160271541, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 5635836180088380747, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 5884884705227387567, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    - target: {fileID: 6220766699795776869, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983a987a0441e504ba2ed5b4bba085fd, type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1ebb75c12ef91014e94524019e01192d, type: 3}
+--- !u!1 &1888107669
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1888107670}
+  - component: {fileID: 1888107673}
+  - component: {fileID: 1888107672}
+  - component: {fileID: 1888107671}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1888107670
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888107669}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2049112421}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1888107671
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888107669}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 1.5, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 30
+  m_LookaheadIgnoreY: 1
+  m_HorizontalDamping: 0
+  m_VerticalDamping: 0
+  m_ScreenX: 0.5
+  m_ScreenY: 0.55
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &1888107672
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888107669}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BindingMode: 5
+  m_FollowOffset: {x: 0, y: 6, z: -10}
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_AngularDampingMode: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AngularDamping: 0
+  m_Heading:
+    m_Definition: 2
+    m_VelocityFilterStrength: 4
+    m_Bias: 0
+  m_RecenterToTargetHeading:
+    m_enabled: 0
+    m_WaitTime: 1
+    m_RecenteringTime: 2
+    m_LegacyHeadingDefinition: -1
+    m_LegacyVelocityFilterStrength: -1
+  m_XAxis:
+    Value: 0
+    m_SpeedMode: 0
+    m_MaxSpeed: 300
+    m_AccelTime: 0.1
+    m_DecelTime: 0.1
+    m_InputAxisName: 
+    m_InputAxisValue: 0
+    m_InvertInput: 1
+    m_MinValue: -180
+    m_MaxValue: 180
+    m_Wrap: 1
+    m_Recentering:
+      m_enabled: 0
+      m_WaitTime: 1
+      m_RecenteringTime: 2
+      m_LegacyHeadingDefinition: -1
+      m_LegacyVelocityFilterStrength: -1
+  m_LegacyRadius: 3.4028235e+38
+  m_LegacyHeightOffset: 3.4028235e+38
+  m_LegacyHeadingBias: 3.4028235e+38
+  m_HeadingIsSlave: 1
+--- !u!114 &1888107673
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888107669}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1961065787
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1961065790}
+  - component: {fileID: 1961065789}
+  - component: {fileID: 1961065788}
+  - component: {fileID: 1961065792}
+  - component: {fileID: 1961065791}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1961065788
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961065787}
+  m_Enabled: 1
+--- !u!20 &1961065789
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961065787}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.1
+  far clip plane: 2000
+  field of view: 40
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1961065790
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961065787}
+  m_LocalRotation: {x: 0.18778464, y: -0.20536137, z: 0.040184725, w: 0.9596608}
+  m_LocalPosition: {x: 4.712467, y: 6.03, z: -24.900238}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1961065791
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961065787}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+--- !u!114 &1961065792
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961065787}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72ece51f2901e7445ab60da3685d6b5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowDebugText: 0
+  m_ShowCameraFrustum: 0
+  m_IgnoreTimeScale: 0
+  m_WorldUpOverride: {fileID: 0}
+  m_UpdateMethod: 2
+  m_BlendUpdateMethod: 1
+  m_DefaultBlend:
+    m_Style: 1
+    m_Time: 2
+    m_CustomCurve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+  m_CustomBlends: {fileID: 0}
+  m_CameraCutEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CameraActivatedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &2018663598
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2018663599}
+  - component: {fileID: 2018663602}
+  - component: {fileID: 2018663601}
+  - component: {fileID: 2018663600}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2018663599
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2018663598}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 233317033}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2018663600
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2018663598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 1, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0
+  m_VerticalDamping: 0
+  m_ScreenX: 0.5
+  m_ScreenY: 0.6
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &2018663601
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2018663598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BindingMode: 5
+  m_FollowOffset: {x: 0, y: 6, z: -10}
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_AngularDampingMode: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AngularDamping: 0
+  m_Heading:
+    m_Definition: 2
+    m_VelocityFilterStrength: 4
+    m_Bias: 0
+  m_RecenterToTargetHeading:
+    m_enabled: 0
+    m_WaitTime: 1
+    m_RecenteringTime: 2
+    m_LegacyHeadingDefinition: -1
+    m_LegacyVelocityFilterStrength: -1
+  m_XAxis:
+    Value: 0
+    m_SpeedMode: 0
+    m_MaxSpeed: 300
+    m_AccelTime: 0.1
+    m_DecelTime: 0.1
+    m_InputAxisName: 
+    m_InputAxisValue: 0
+    m_InvertInput: 1
+    m_MinValue: -180
+    m_MaxValue: 180
+    m_Wrap: 1
+    m_Recentering:
+      m_enabled: 0
+      m_WaitTime: 1
+      m_RecenteringTime: 2
+      m_LegacyHeadingDefinition: -1
+      m_LegacyVelocityFilterStrength: -1
+  m_LegacyRadius: 3.4028235e+38
+  m_LegacyHeightOffset: 3.4028235e+38
+  m_LegacyHeadingBias: 3.4028235e+38
+  m_HeadingIsSlave: 1
+--- !u!114 &2018663602
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2018663598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2020721998
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2020721999}
+  - component: {fileID: 2020722002}
+  - component: {fileID: 2020722001}
+  - component: {fileID: 2020722000}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2020721999
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2020721998}
+  m_LocalRotation: {x: -0.24286506, y: 0.42750385, z: -0.12038752, w: 0.86241746}
+  m_LocalPosition: {x: -0.99633694, y: 0.6658721, z: 9.884593}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 135922105}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2020722000
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2020721998}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e8b78ac948f05a46a6d8339a503172b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2020722001
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2020721998}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fa7155796051b734daa718462081dc5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BindingMode: 4
+  m_FollowOffset: {x: 0, y: 5.43, z: -10.11}
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_AngularDampingMode: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AngularDamping: 0
+--- !u!114 &2020722002
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2020721998}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2049112419
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2049112421}
+  - component: {fileID: 2049112420}
+  m_Layer: 0
+  m_Name: MiddleRig
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2049112420
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2049112419}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  - Header
+  - Extensions
+  - m_Priority
+  - m_Transitions
+  - m_Follow
+  - m_StandbyUpdate
+  - m_Lens
+  m_LockStageInInspector: 00000000
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_Lens:
+    FieldOfView: 40
+    OrthographicSize: 10
+    NearClipPlane: 0.1
+    FarClipPlane: 2000
+    Dutch: 0
+    LensShift: {x: 0, y: 0}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 1888107670}
+--- !u!4 &2049112421
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2049112419}
+  m_LocalRotation: {x: 0.18778461, y: -0.20536137, z: 0.040184718, w: 0.9596608}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1888107670}
+  m_Father: {fileID: 1502793902}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2084548121
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2084548122}
+  - component: {fileID: 2084548125}
+  - component: {fileID: 2084548124}
+  - component: {fileID: 2084548123}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2084548122
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2084548121}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1069947042}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2084548123
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2084548121}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 2, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0
+  m_VerticalDamping: 0
+  m_ScreenX: 0.5
+  m_ScreenY: 0.5
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &2084548124
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2084548121}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BindingMode: 5
+  m_FollowOffset: {x: 0, y: 6, z: -10}
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_AngularDampingMode: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AngularDamping: 0
+  m_Heading:
+    m_Definition: 2
+    m_VelocityFilterStrength: 4
+    m_Bias: 0
+  m_RecenterToTargetHeading:
+    m_enabled: 0
+    m_WaitTime: 1
+    m_RecenteringTime: 2
+    m_LegacyHeadingDefinition: -1
+    m_LegacyVelocityFilterStrength: -1
+  m_XAxis:
+    Value: 0
+    m_SpeedMode: 0
+    m_MaxSpeed: 300
+    m_AccelTime: 0.1
+    m_DecelTime: 0.1
+    m_InputAxisName: 
+    m_InputAxisValue: 0
+    m_InvertInput: 1
+    m_MinValue: -180
+    m_MaxValue: 180
+    m_Wrap: 1
+    m_Recentering:
+      m_enabled: 0
+      m_WaitTime: 1
+      m_RecenteringTime: 2
+      m_LegacyHeadingDefinition: -1
+      m_LegacyVelocityFilterStrength: -1
+  m_LegacyRadius: 3.4028235e+38
+  m_LegacyHeightOffset: 3.4028235e+38
+  m_LegacyHeadingBias: 3.4028235e+38
+  m_HeadingIsSlave: 1
+--- !u!114 &2084548125
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2084548121}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &2370768318719443585
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 364731123117828817, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_Name
+      value: SmallBuilding
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -17.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9.51
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.019262606
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.99981445
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 384383464925863578, guid: 1ebb75c12ef91014e94524019e01192d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -2.207
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1ebb75c12ef91014e94524019e01192d, type: 3}
+--- !u!1001 &6560919939139749480
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 17.23
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 24.74
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.039645787
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.08316175
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.05584523
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.99417996
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 3.9880002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -9.799001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160299325435046207, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -6.7720003
+      objectReference: {fileID: 0}
+    - target: {fileID: 7500093032234365829, guid: fe3004506b4c6cd478eb2cca639b3713,
+        type: 3}
+      propertyPath: m_Name
+      value: TreeRound
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fe3004506b4c6cd478eb2cca639b3713, type: 3}

--- a/UOP1_Project/Assets/Tests/PlayerFSM/CharControllerFSM.unity.meta
+++ b/UOP1_Project/Assets/Tests/PlayerFSM/CharControllerFSM.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 81b95a7dc2da37f4dabf00db86a74453
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
forum: https://forum.unity.com/threads/character-state-machine.979371/page-3#post-6432053
card: https://open.codecks.io/unity-open-project-1/decks/15/card/157-state-machine

This PR is not ready to merge. It is here just to show another way to do FSM.

I like SO a lot! But when you need Component-like behavior you're using MonoBehaviours, don't you?
That's why I implemented this quite simple example using MB instead of SO.
Also, there is a very generic StateMachine that can be used without both MB and SO. 

Cons:
- a little overhead from enabling/disabling whole GameObjects.
- someone may use FSM prefabs like SO and that really bad!!! **(no)**.

Pros:
- It can use standard Unity components out of the box 
- Everybody can just write Monobehaviours with OnEnable/OnDisable
- It can be built/stored either in a scene or a prefab
- It can be reused and modified via prefab variants
- It even supports nested state machines
- It doesn't require to do extra steps to instantiate the whole FSM graph
- It does not require any editor scripts/UI (state changes can be observed in the hierarchy)
- It would be possible to separate states from transitions if necessary
- It is possible to create a custom node editor for it (which is easy to add on top) but it is not necessary at all.
- **It just like SO but a lot easier to implement and maintain**

(thanks peaj_metric for this list of pros and cons)

### Content
In the root of `Assets/Scripts/StateMachines` folder you will find a bunch of interfaces that are enough to create any kind of FSM out of them:
- IState
- IStateAction
- ITransition
- ICondition

Also, there is a generic StateMachine that implements core FSM functionality.[here](https://github.com/UnityTechnologies/open-project-1/pull/98/files?file-filters%5B%5D=.cs&file-filters%5B%5D=.meta&file-filters%5B%5D=.unity#diff-8df56ec9e13227377df9130b58db155c0633e1222b462471e556dc06932385d1)


`Assets/Scripts/StateMachines/Mono` - FSM using MonoBehaviours. 
I want to draw your attention to MonoStateMachine which is not repeating FSM's core functionality and uses generic StateMachine instead. 


`Assets/Scripts/StateMachines/Scriptable` - FSM using ScriptableObjects. 
Again, ScriptableStateMachine doesn't implement FSM by itself. My SO-FSM uses a transition table rather than store transitions right in the state.


`Assets/Scripts/StateMachines/Plain` - FSM using plain C# classes. 
Nothing special, just a way to create StateMachine from code. Includes PlainStateMachineBuilder as a fluent builder. Just an example that this stuff is quite easy to implement if we really need to.


`Assets/Scripts/PlayerStateMachine` - FSM that implements current player movement using the MonoBehaviours approach.
Just a bunch of StateActions and Conditions. 
Important: I had to create CharacterMotor(that is very similar to Character class) as a data container for PlayerStateActions. 
Please also note, I spent on this very little time, so yeah... PlayerStateActions are poorly implemented, but who cares, it's just an example of a thing that no one interested in, XD


`Assets/Tests/PlayerFSM` - test scene where I did my dirty tricks. It contains 3 player characters: 
 - green - current, default
 - blue - FSM version
 - violet - prefab variant from previous(blue) one that adds ability to double jump

That how player's FSM looks in editor:
![image](https://user-images.githubusercontent.com/23558898/96439903-da3a5f00-120f-11eb-88fe-a9c1904dbeb0.png)

And that how looks FSM with added double jump:
![image](https://user-images.githubusercontent.com/23558898/96440131-34d3bb00-1210-11eb-8429-da988e81553c.png)

Video: https://youtu.be/iPtt0snKloI

