### PR TITLE
Fixed the StateTransitionSO error when grouping conditions

### DIFF
--- a/UOP1_Project/Assets/Scripts/StateMachine/ScriptableObjects/StateTransitionSO.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/ScriptableObjects/StateTransitionSO.cs
@@ -40,8 +40,8 @@ namespace UOP1.StateMachine.ScriptableObjects
 			List<int> resultGroupsList = new List<int>();
 			for (int i = 0; i < count; i++)
 			{
-				int idx = i;
 				resultGroupsList.Add(1);
+				int idx = resultGroupsList.Count - 1;
 				while (i < count - 1 && conditionUsages[i].Operator == Operator.And)
 				{
 					i++;


### PR DESCRIPTION
Issue: https://github.com/UnityTechnologies/open-project-1/issues/111

The source of the exception was the variable _idx_ following the condition index instead of the last index of _resultGroupsList_
This would give errors every time their values differ since it is expected to have less groups than conditions.

To test, reproduce the steps on the issue or add a bigger number of conditions with different operator combinations, specially chaining AND operators together and some OR operators between those chains.