### PR TITLE
Applied the tag EditorOnly to logical section GameObjects

### DIFF
--- a/UOP1_Project/Assets/Scenes/CharController.unity
+++ b/UOP1_Project/Assets/Scenes/CharController.unity
@@ -653,7 +653,7 @@ GameObject:
   - component: {fileID: 395747638}
   m_Layer: 0
   m_Name: ---------  ENVIRONMENT --------------
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -729,7 +729,7 @@ GameObject:
   - component: {fileID: 695792053}
   m_Layer: 0
   m_Name: ---------  MANAGERS --------------
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1041,7 +1041,7 @@ GameObject:
   - component: {fileID: 826602624}
   m_Layer: 0
   m_Name: ---------  LIGHTING --------------
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1350,7 +1350,7 @@ GameObject:
   - component: {fileID: 1069143687}
   m_Layer: 0
   m_Name: ---------  CAMERA WORK --------------
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1908,7 +1908,7 @@ GameObject:
   - component: {fileID: 1523164312}
   m_Layer: 0
   m_Name: ---------  GAMEPLAY --------------
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0


### PR DESCRIPTION
There was no forum thread for this PR.
This PR updates the scene so that it meets the conventions.
These changes are necessary to keep up with proper conventions.
I selected all the logical section empty game objects and applied the EditorOnly tag to them.