### PR TITLE
Fixed the character switching to JumpDescent state while walking

### DIFF
--- a/UOP1_Project/Assets/ScriptableObjects/Protagonist/Transitions/BeginJumpDescent.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/Protagonist/Transitions/BeginJumpDescent.asset
@@ -16,7 +16,13 @@ MonoBehaviour:
   _conditions:
   - ExpectedResult: 1
     Condition: {fileID: 11400000, guid: 620f4efd93744084a8ac9ba272f093dc, type: 2}
+    Operator: 0
+  - ExpectedResult: 1
+    Condition: {fileID: 11400000, guid: c7258bdb2558a214f916c8b5b3c0fa1f, type: 2}
     Operator: 1
   - ExpectedResult: 0
     Condition: {fileID: 11400000, guid: bf6a2f4642738ac4f8e84bcdf1cb5f93, type: 2}
+    Operator: 0
+  - ExpectedResult: 1
+    Condition: {fileID: 11400000, guid: c7258bdb2558a214f916c8b5b3c0fa1f, type: 2}
     Operator: 0


### PR DESCRIPTION
Issue: https://github.com/UnityTechnologies/open-project-1/issues/115
This PR also depends on this issue being fixed first: https://github.com/UnityTechnologies/open-project-1/issues/111

Fixed by changing the conditions of the transition BeginJumpDescent to check if the character is in the air.
This avoids the state changing to JumpDescent while the character is in the ground.

Test by moving and jumping the character around the scene with the state machine debug function active.
The character should enter in JumpDescent state only when falling from jumping or from walking towards a ledge.

### From
![2020-10-27 10_31_29-Window](https://user-images.githubusercontent.com/16827309/97362018-2aa06500-187f-11eb-8a7b-1a9666d858ee.png)

### To
![2020-10-27 10_30_54-Window](https://user-images.githubusercontent.com/16827309/97362093-4146bc00-187f-11eb-9238-d5a9ba40258b.png)
