### PR TITLE
Allow switching from the Idle state to Sliding or JumpDescending

### DIFF
--- a/UOP1_Project/Assets/ScriptableObjects/Protagonist/States/Idle.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/Protagonist/States/Idle.asset
@@ -18,3 +18,5 @@ MonoBehaviour:
   _transitions:
   - {fileID: 11400000, guid: 15394873b380a284bbf425c98e1f7ff5, type: 2}
   - {fileID: 11400000, guid: a397ed7ab7a1ef24082946a116ba98ed, type: 2}
+  - {fileID: 11400000, guid: 06d55bd43e60a1a469545b18bca1061c, type: 2}
+  - {fileID: 11400000, guid: 54b0ebefbe8767c41a7e981ea0857f68, type: 2}


### PR DESCRIPTION
Issue: https://github.com/UnityTechnologies/open-project-1/issues/123

Changed the Idle state to support the transition to StartSliding and BeginJumpDescent.
This doubles as a fix and to support any future plans for moving or disappearing objects in the environment that the character can step on.

I haven't added a transition between JumpDescending and Sliding due to some strange behaviors when jumping across small, but steep, slopes.

To Test, check if the character is sliding in any steep slopes by following the steps in the issue.

Additionally:
- Add a dynamic platform in the environment (with collider and rigidbody) (suggestion: Cube(8))
- Enter Play Mode
- Move the character to step on the platform
- Activate the state machine debug option
- Rotate the platform on the X or Z axis until the character starts sliding
- Move or Delete the platform so the character can fall without moving