### PR TITLE
Applied the tag EditorOnly to logical section GameObjects in the Beach scene

### DIFF
--- a/UOP1_Project/Assets/Scenes/LoadingTest/Beach.unity
+++ b/UOP1_Project/Assets/Scenes/LoadingTest/Beach.unity
@@ -584,7 +584,7 @@ GameObject:
   - component: {fileID: 395747638}
   m_Layer: 0
   m_Name: ---------  ENVIRONMENT --------------
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -614,7 +614,7 @@ GameObject:
   - component: {fileID: 695792053}
   m_Layer: 0
   m_Name: ---------  MANAGERS --------------
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1036,7 +1036,7 @@ GameObject:
   - component: {fileID: 826602624}
   m_Layer: 0
   m_Name: ---------  LIGHTING --------------
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1252,7 +1252,7 @@ GameObject:
   - component: {fileID: 1069143687}
   m_Layer: 0
   m_Name: ---------  CAMERA WORK --------------
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1841,7 +1841,7 @@ GameObject:
   - component: {fileID: 1523164312}
   m_Layer: 0
   m_Name: ---------  GAMEPLAY --------------
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0


### PR DESCRIPTION
There was no forum thread for this PR.
This PR updates the scene so that it meets the conventions.
These changes are necessary to keep up with proper conventions.
I selected all the logical section empty game objects and applied the EditorOnly tag to them. I then tested it and everything ran smooth.
