### PR TITLE
Fix baked geometry becomes black when no dynamic geometry is on screen

### DIFF
--- a/UOP1_Project/Assets/Shaders/CustomHLSL/CustomLighting.hlsl
+++ b/UOP1_Project/Assets/Shaders/CustomHLSL/CustomLighting.hlsl
@@ -18,13 +18,13 @@ void MainLight_float(float3 WorldPos, out float3 Direction, out float3 Color, ou
 
 	#if !defined(_MAIN_LIGHT_SHADOWS) || defined(_RECEIVE_SHADOWS_OFF)
 		ShadowAtten = 1.0h;
-	#endif
-
-	ShadowSamplingData shadowSamplingData = GetMainLightShadowSamplingData();
-	float shadowStrength = GetMainLightShadowStrength();
-	ShadowAtten = SampleShadowmap(shadowCoord, TEXTURE2D_ARGS(_MainLightShadowmapTexture,
-	sampler_MainLightShadowmapTexture),
-	shadowSamplingData, shadowStrength, false);
+    #else
+	    ShadowSamplingData shadowSamplingData = GetMainLightShadowSamplingData();
+	    float shadowStrength = GetMainLightShadowStrength();
+	    ShadowAtten = SampleShadowmap(shadowCoord, TEXTURE2D_ARGS(_MainLightShadowmapTexture,
+	    sampler_MainLightShadowmapTexture),
+	    shadowSamplingData, shadowStrength, false);
+    #endif
 #endif
 }
 


### PR DESCRIPTION
Link: #108
There was missing `#else` condition
Now there are no black textures after light baking (look at reproducing issue section)