### PR TITLE
Changed Awake() to Start() in SpawnSystem (#120)

### DIFF
--- a/UOP1_Project/Assets/Scripts/SpawnSystem.cs
+++ b/UOP1_Project/Assets/Scripts/SpawnSystem.cs
@@ -14,7 +14,7 @@ public class SpawnSystem : MonoBehaviour
 	[SerializeField] private CameraManager _cameraManager;
 	[SerializeField] private Transform[] _spawnLocations;
 
-	void Awake()
+	void Start()
 	{
 		try
 		{


### PR DESCRIPTION
Issue #120 

When the scenes are additively loaded, GameObject instantiation should be put in Start(), because Awake() is exectuted before the new scene becomes active.

Reference thread: https://forum.unity.com/threads/additive-scene-loading-and-awake.660379/
