### PR TITLE
Input checks from Phase.Started => Phase.Performed

### DIFF
--- a/UOP1_Project/Assets/Scripts/Input/InputReader.cs
+++ b/UOP1_Project/Assets/Scripts/Input/InputReader.cs
@@ -34,28 +34,28 @@ public class InputReader : ScriptableObject, GameInput.IGameplayActions
 	public void OnAttack(InputAction.CallbackContext context)
 	{
 		if (attackEvent != null
-			&& context.phase == InputActionPhase.Started)
+			&& context.phase == InputActionPhase.Performed)
 			attackEvent.Invoke();
 	}
 
 	public void OnExtraAction(InputAction.CallbackContext context)
 	{
 		if (extraActionEvent != null
-			&& context.phase == InputActionPhase.Started)
+			&& context.phase == InputActionPhase.Performed)
 			extraActionEvent.Invoke();
 	}
 
 	public void OnInteract(InputAction.CallbackContext context)
 	{
 		if (interactEvent != null
-			&& context.phase == InputActionPhase.Started)
+			&& context.phase == InputActionPhase.Performed)
 			interactEvent.Invoke();
 	}
 
 	public void OnJump(InputAction.CallbackContext context)
 	{
 		if (jumpEvent != null
-			&& context.phase == InputActionPhase.Started)
+			&& context.phase == InputActionPhase.Performed)
 			jumpEvent.Invoke();
 
 		if (jumpCanceledEvent != null
@@ -74,7 +74,7 @@ public class InputReader : ScriptableObject, GameInput.IGameplayActions
 	public void OnPause(InputAction.CallbackContext context)
 	{
 		if (pauseEvent != null
-			&& context.phase == InputActionPhase.Started)
+			&& context.phase == InputActionPhase.Performed)
 			pauseEvent.Invoke();
 	}
 


### PR DESCRIPTION
This PR changes input checks inside the InputReader.cs file from the InputActionPhase.Started phase to the Performed phase.

The input system provides the ability to define 'interactions' - different actions which fire off on the same button press depending on the length of the press (Hold, Multi-Tap, etc).

Actions are detected in the Started Phase, and considered complete in the Performed phase.  Currently we only look at the started phase, which will cause issues if we ever want to use the interaction system.

Should not affect any existing functionality, but just conform to best practice (all the official guides show performing callbacks from performed phase, not started phase).

More details here: https://forum.unity.com/threads/controls.980073/#post-6484114
