### PR TITLE
Repaint when selecting spawn location

### DIFF
--- a/UOP1_Project/Assets/Scripts/ClickToPlaceHelper.cs
+++ b/UOP1_Project/Assets/Scripts/ClickToPlaceHelper.cs
@@ -38,6 +38,10 @@ public class ClickToPlaceHelper : MonoBehaviour
 		{
 			_spawnPosition = hit.point + Vector3.up * _verticalOffset;
 
+			if (currentGUIEvent.type == EventType.MouseMove)
+			{
+				HandleUtility.Repaint();
+			}
 			if (currentGUIEvent.type == EventType.MouseDown
 				&& currentGUIEvent.button == 0) // Wait for Left mouse button down
 			{


### PR DESCRIPTION
When we wanted to click to select spawn location while not in play mode the gizmos was laggy. I added to repaint on mouse move event to always paint the exact location.

[Forum Thread](https://forum.unity.com/threads/spawn-system.980658/)

This PR improves a little bit the **click to set spawn location** feature introduced by @jamercer . Really good work btw, it's a very useful tool.

This change basically makes sure that gizmo cube location is exact at all times while not in play mode.

I just call HandleUtility.Repaint when mouse is moved while we are positioning the spawn location 