### PR TITLE
Added an Editor assembly for the FSM editor scripts

### DIFF
--- a/UOP1_Project/Assets/Scripts/StateMachine/Editor/UOP1.StateMachine.Editor.asmdef
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Editor/UOP1.StateMachine.Editor.asmdef
@@ -1,0 +1,17 @@
+{
+    "name": "UOP1.StateMachine.Editor",
+    "references": [
+        "GUID:784148ec08432ab4a974dd364656dae9"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/UOP1_Project/Assets/Scripts/StateMachine/Editor/UOP1.StateMachine.Editor.asmdef.meta
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Editor/UOP1.StateMachine.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8c0a18d9d0551b541815cb03f6f62fb4
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This assembly will mark the editor code for removal when building the project since the Editor folder does not do this automatically inside another assembly.