### PR TITLE
Delete unused metafile for Sound folder

### DIFF
--- a/UOP1_Project/Assets/Scripts/Sound.meta
+++ b/UOP1_Project/Assets/Scripts/Sound.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 7f027bef4434b504f9b49753067f5ea1
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
**[for Bugfix PRs]**  
Issue https://github.com/UnityTechnologies/open-project-1/issues/165

Looks like an extra meta file made it through after our recent Audio System merge. The meta file `Sound.meta` was referencing a folder that no longer exists.