### PR TITLE
fix: Project won't compile due to a reference to UnityEditor (#157)

### DIFF
--- a/UOP1_Project/Assets/Scripts/ClickToPlaceHelper.cs
+++ b/UOP1_Project/Assets/Scripts/ClickToPlaceHelper.cs
@@ -6,68 +6,36 @@ using UnityEngine;
 public class ClickToPlaceHelper : MonoBehaviour
 {
 	[Tooltip("Vertical offset above the clicked point. Useful to avoid spawn points to be directly ON the geometry which might cause issues.")]
-	[SerializeField] float _verticalOffset = 0.1f;
+	[SerializeField] private float _verticalOffset = 0.1f;
 
-	private Vector3 _spawnPosition;
-	private bool _displaySpawnPosition = false;
+	private Vector3 _targetPosition;
+	private bool _targeting = false;
 
-	private delegate void ButtonAction();
-	private ButtonAction myButtonAction;
+	public bool targeting => _targeting;
 
 	private void OnDrawGizmos()
 	{
-		if (_displaySpawnPosition)
+		if (_targeting)
 		{
 			Gizmos.color = Color.green;
-			Gizmos.DrawCube(_spawnPosition, Vector3.one * 0.3f);
+			Gizmos.DrawCube(_targetPosition, Vector3.one * 0.3f);
 		}
 	}
 
-	void OnMouseClick(SceneView scene)
+	public void BeginTargeting()
 	{
-		Event currentGUIEvent = Event.current;
-
-		Vector3 mousePos = currentGUIEvent.mousePosition;
-		float pixelsPerPoint = EditorGUIUtility.pixelsPerPoint;
-		mousePos.y = scene.camera.pixelHeight - mousePos.y * pixelsPerPoint;
-		mousePos.x *= pixelsPerPoint;
-
-		Ray ray = scene.camera.ScreenPointToRay(mousePos);
-
-		if (Physics.Raycast(ray, out RaycastHit hit))
-		{
-			_spawnPosition = hit.point + Vector3.up * _verticalOffset;
-
-			if (currentGUIEvent.type == EventType.MouseMove)
-			{
-				HandleUtility.Repaint();
-			}
-			if (currentGUIEvent.type == EventType.MouseDown
-				&& currentGUIEvent.button == 0) // Wait for Left mouse button down
-			{
-				myButtonAction();
-				SceneView.duringSceneGui -= OnMouseClick;
-				_displaySpawnPosition = false;
-
-				currentGUIEvent.Use(); // This consumes the event, so that other controls/buttons won't be able to use it
-			}
-		}
+		_targeting = true;
+		_targetPosition = transform.position;
 	}
 
-	public void SetSpawnLocationAtCursor()
+	public void UpdateTargeting(Vector3 spawnPosition)
 	{
-		Debug.Log("Use the LMB to position this object");
-		myButtonAction = SetTransform;
-		_displaySpawnPosition = true;
-		SceneView.duringSceneGui += OnMouseClick;
+		_targetPosition = spawnPosition + Vector3.up * _verticalOffset;
 	}
 
-	/// <summary>
-	/// The delegate called when the mouse is clicked in the viewport
-	/// </summary>
-	private void SetTransform()
+	public void EndTargeting()
 	{
-		transform.position = _spawnPosition;
-		Debug.Log("Object moved to " + _spawnPosition);
+		_targeting = false;
+		transform.position = _targetPosition;
 	}
 }

--- a/UOP1_Project/Assets/Scripts/ClickToPlaceHelper.cs
+++ b/UOP1_Project/Assets/Scripts/ClickToPlaceHelper.cs
@@ -1,5 +1,4 @@
-﻿using UnityEditor;
-using UnityEngine;
+﻿using UnityEngine;
 
 [ExecuteInEditMode]
 [AddComponentMenu("UOP1/Tools/Click to Place")]
@@ -9,13 +8,12 @@ public class ClickToPlaceHelper : MonoBehaviour
 	[SerializeField] private float _verticalOffset = 0.1f;
 
 	private Vector3 _targetPosition;
-	private bool _targeting = false;
 
-	public bool targeting => _targeting;
+	public bool IsTargeting { get; private set; }
 
 	private void OnDrawGizmos()
 	{
-		if (_targeting)
+		if (IsTargeting)
 		{
 			Gizmos.color = Color.green;
 			Gizmos.DrawCube(_targetPosition, Vector3.one * 0.3f);
@@ -24,7 +22,7 @@ public class ClickToPlaceHelper : MonoBehaviour
 
 	public void BeginTargeting()
 	{
-		_targeting = true;
+		IsTargeting = true;
 		_targetPosition = transform.position;
 	}
 
@@ -35,7 +33,7 @@ public class ClickToPlaceHelper : MonoBehaviour
 
 	public void EndTargeting()
 	{
-		_targeting = false;
+		IsTargeting = false;
 		transform.position = _targetPosition;
 	}
 }

--- a/UOP1_Project/Assets/Scripts/Editor/SpawnLocationEditor.cs
+++ b/UOP1_Project/Assets/Scripts/Editor/SpawnLocationEditor.cs
@@ -4,15 +4,15 @@ using UnityEngine;
 [CustomEditor(typeof(ClickToPlaceHelper))]
 public class ClickToPlaceHelperEditor : Editor
 {
-	private ClickToPlaceHelper helper => target as ClickToPlaceHelper;
+	private ClickToPlaceHelper _clickHelper => target as ClickToPlaceHelper;
 
 	public override void OnInspectorGUI()
 	{
 		base.OnInspectorGUI();
 
-		if (GUILayout.Button("Place at Mouse cursor") && !helper.targeting)
+		if (GUILayout.Button("Place at Mouse cursor") && !_clickHelper.IsTargeting)
 		{
-			helper.BeginTargeting();
+			_clickHelper.BeginTargeting();
 			SceneView.duringSceneGui += DuringSceneGui;
 		}
 	}
@@ -30,7 +30,7 @@ public class ClickToPlaceHelperEditor : Editor
 
 		if (Physics.Raycast(ray, out RaycastHit hit))
 		{
-			helper.UpdateTargeting(hit.point);
+			_clickHelper.UpdateTargeting(hit.point);
 		}
 
 		switch (currentGUIEvent.type)
@@ -41,7 +41,7 @@ public class ClickToPlaceHelperEditor : Editor
 			case EventType.MouseDown:
 				if (currentGUIEvent.button == 0) // Wait for Left mouse button down
 				{
-					helper.EndTargeting();
+					_clickHelper.EndTargeting();
 					SceneView.duringSceneGui -= DuringSceneGui;
 					currentGUIEvent.Use(); // This consumes the event, so that other controls/buttons won't be able to use it
 				}

--- a/UOP1_Project/Assets/Scripts/Editor/SpawnLocationEditor.cs
+++ b/UOP1_Project/Assets/Scripts/Editor/SpawnLocationEditor.cs
@@ -4,15 +4,48 @@ using UnityEngine;
 [CustomEditor(typeof(ClickToPlaceHelper))]
 public class ClickToPlaceHelperEditor : Editor
 {
+	private ClickToPlaceHelper helper => target as ClickToPlaceHelper;
+
 	public override void OnInspectorGUI()
 	{
 		base.OnInspectorGUI();
 
-		ClickToPlaceHelper myTarget = target as ClickToPlaceHelper;
-
-		if (GUILayout.Button("Place at Mouse cursor"))
+		if (GUILayout.Button("Place at Mouse cursor") && !helper.targeting)
 		{
-			myTarget.SetSpawnLocationAtCursor();
+			helper.BeginTargeting();
+			SceneView.duringSceneGui += DuringSceneGui;
+		}
+	}
+
+	private void DuringSceneGui(SceneView sceneView)
+	{
+		Event currentGUIEvent = Event.current;
+
+		Vector3 mousePos = currentGUIEvent.mousePosition;
+		float pixelsPerPoint = EditorGUIUtility.pixelsPerPoint;
+		mousePos.y = sceneView.camera.pixelHeight - mousePos.y * pixelsPerPoint;
+		mousePos.x *= pixelsPerPoint;
+
+		Ray ray = sceneView.camera.ScreenPointToRay(mousePos);
+
+		if (Physics.Raycast(ray, out RaycastHit hit))
+		{
+			helper.UpdateTargeting(hit.point);
+		}
+
+		switch (currentGUIEvent.type)
+		{
+			case EventType.MouseMove:
+				HandleUtility.Repaint();
+				break;
+			case EventType.MouseDown:
+				if (currentGUIEvent.button == 0) // Wait for Left mouse button down
+				{
+					helper.EndTargeting();
+					SceneView.duringSceneGui -= DuringSceneGui;
+					currentGUIEvent.Use(); // This consumes the event, so that other controls/buttons won't be able to use it
+				}
+				break;
 		}
 	}
 }


### PR DESCRIPTION
Is this PR linked to an issue? If so please link it here, if not please create one first, then link it.
[#157](https://github.com/UnityTechnologies/open-project-1/issues/157) 

Is there a forum thread linked to this issue? If so please link it here. 
No 

How did you resolve this issue?  
I reorganized **ClieckToPlaceHelper** and **SpawnLocationEditor** classes in the way when all editor-dependent functionality were placed in **SpawnLocationEditor** class in Editor folder. 

How can it be verified that the issue has actually been resolved?  
Just try to build project and check there is no compilation errors. 
