### PR TITLE
Update ReplaceTool.cs

### DIFF
--- a/UOP1_Project/Assets/Scripts/Editor/ReplaceTool.cs
+++ b/UOP1_Project/Assets/Scripts/Editor/ReplaceTool.cs
@@ -137,7 +137,11 @@ public class ReplaceTool : EditorWindow
 		{
 			var go = objectToReplace[i];
 			Undo.RegisterCompleteObjectUndo(go, "Saving game object state");
-			var inst = Instantiate(replaceObject, go.transform.position, go.transform.rotation, go.transform.parent);
+			var inst = (GameObject)PrefabUtility.InstantiatePrefab(replaceObject);
+			inst.transform.position = go.transform.position;
+			inst.transform.rotation = go.transform.rotation;
+			inst.transform.parent = go.transform.parent;
+
 			inst.transform.localScale = go.transform.localScale;
 			Undo.RegisterCreatedObjectUndo(inst, "Replacement creation.");
 			foreach (Transform child in go.transform)


### PR DESCRIPTION

**[for Bugfix PRs]**  
https://open.codecks.io/unity-open-project-1/decks/undefined-/card/18v-replacement-tool-instantiates-objects-not-prefabs
No Forum Link
I implemented this by researching how the PrefabUtility API worked on the Unity manual
Can be verified by using the replace tool and observing that objects are linked to a prefab  
