### PR TITLE
Issue #229 : prevent old pig from triggering anything in new scene

### DIFF
--- a/UOP1_Project/Assets/Scripts/SceneManagement/LocationExit.cs
+++ b/UOP1_Project/Assets/Scripts/SceneManagement/LocationExit.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.SceneManagement;
 
 /// <summary>
 /// This class goes on a trigger which, when entered, sends the player to another Location
@@ -15,8 +16,9 @@ public class LocationExit : MonoBehaviour
 
 	private void OnTriggerEnter(Collider other)
 	{
-		if (other.CompareTag("Player"))
+		if (other.CompareTag("Player") && other.gameObject.scene == SceneManager.GetActiveScene())
 		{
+			Destroy(other.gameObject);
 			_locationExitLoadChannel.RaiseEvent(_locationsToLoad, _showLoadScreen);
 		}
 	}


### PR DESCRIPTION
Issue #229 

1) We check that the pig triggering the exit exists in the same scene as the trigger, this way we prevent old pig or new pig triggering exits in mid asynch load states.
2) To prevent old pig maybe taking damage or picking up items or any other effects, I destroy the old pig before loading.

This can be tested by loading from beach to forest to beach multiple times with out exception. 
