### PR TITLE
Hotfix for null checking Transition  Target State.

### DIFF
--- a/UOP1_Project/Assets/Scripts/StateMachine/Editor/TransitionTableEditor.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Editor/TransitionTableEditor.cs
@@ -382,15 +382,15 @@ namespace UOP1.StateMachine.Editor
 				var serializedTransition = new SerializedTransition(_transitions, i);
 				if (serializedTransition.FromState.objectReferenceValue == null)
 				{
-					Debug.LogError("Transition with invalid state found in table " + serializedObject.targetObject.name + ", deleting...");
+					Debug.LogError("Transition with invalid \"From State\" found in table " + serializedObject.targetObject.name + ", deleting...");
 					_transitions.DeleteArrayElementAtIndex(i);
 					serializedObject.ApplyModifiedProperties();
 					Reset();
 					return;
 				}
-				if (serializedTransition.FromState.objectReferenceValue == null)
+				if (serializedTransition.ToState.objectReferenceValue == null)
 				{
-					Debug.LogError("Transition with invalid state found in table " + serializedObject.targetObject.name + ", deleting...");
+					Debug.LogError("Transition with invalid \"Target State\" found in table " + serializedObject.targetObject.name + ", deleting...");
 					_transitions.DeleteArrayElementAtIndex(i);
 					serializedObject.ApplyModifiedProperties();
 					Reset();


### PR DESCRIPTION
Reviewing #241 I realized that there was an error in `TransitionTableEditor.cs`. I was null checking `FromState` twice and not checking `ToState`.

This should only happen if a **State** asset is deleted _after_ creating a **Transition** that uses it, so it's very rare and probably why it went undetected. 