### PR TITLE
[WIP] Simplified Input to use Composite

### DIFF
--- a/UOP1_Project/Assets/Scenes/TestingGround.unity
+++ b/UOP1_Project/Assets/Scenes/TestingGround.unity
@@ -2096,6 +2096,27 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 69359815}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &73056683 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8745341641394998848, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1810604289}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &73056684
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 73056683}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fb7194dc27b9df64c8beca7482ee8e0d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  PlayerIndex: -1
+  XYAxis: {fileID: 4056236503403311910, guid: 47a7bd10b734b954e95d4dbf166f5578, type: 3}
+  ZAxis: {fileID: 0}
 --- !u!1001 &80056452
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -68462,22 +68483,22 @@ PrefabInstance:
     - target: {fileID: 1657732992883833910, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.032304645
+      value: -0.026907127
       objectReference: {fileID: 0}
     - target: {fileID: 1657732992883833910, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.009041826
+      value: 0.0075311027
       objectReference: {fileID: 0}
     - target: {fileID: 1657732992883833910, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9624489
+      value: 0.96261495
       objectReference: {fileID: 0}
     - target: {fileID: 1657732992883833910, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.2693822
+      value: 0.26942867
       objectReference: {fileID: 0}
     - target: {fileID: 1657732992883833910, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
@@ -68677,7 +68698,7 @@ PrefabInstance:
     - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.03230465
+      value: -0.026907131
       objectReference: {fileID: 0}
     - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
@@ -68687,12 +68708,12 @@ PrefabInstance:
     - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.2693822
+      value: 0.2694287
       objectReference: {fileID: 0}
     - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.009041828
+      value: 0.007531104
       objectReference: {fileID: 0}
     - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
@@ -68702,7 +68723,7 @@ PrefabInstance:
     - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9624489
+      value: 0.96261495
       objectReference: {fileID: 0}
     - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}

--- a/UOP1_Project/Assets/Scripts/CameraManager.cs
+++ b/UOP1_Project/Assets/Scripts/CameraManager.cs
@@ -1,16 +1,10 @@
-﻿using System;
-using UnityEngine;
+﻿using UnityEngine;
 using Cinemachine;
 
 public class CameraManager : MonoBehaviour
 {
-	public InputReader inputReader;
 	public Camera mainCamera;
 	public CinemachineFreeLook freeLookVCam;
-	private bool _isRMBPressed;
-
-	[SerializeField, Range(1f, 5f)]
-	private float speed = default;
 
 	public void SetupProtagonistVirtualCamera(Transform target)
 	{
@@ -18,47 +12,4 @@ public class CameraManager : MonoBehaviour
 		freeLookVCam.LookAt = target;
 	}
 
-	private void OnEnable()
-	{
-		inputReader.cameraMoveEvent += OnCameraMove;
-		inputReader.enableMouseControlCameraEvent += OnEnableMouseControlCamera;
-		inputReader.disableMouseControlCameraEvent += OnDisableMouseControlCamera;
-	}
-
-	private void OnDisable()
-	{
-		inputReader.cameraMoveEvent -= OnCameraMove;
-		inputReader.enableMouseControlCameraEvent -= OnEnableMouseControlCamera;
-		inputReader.disableMouseControlCameraEvent -= OnDisableMouseControlCamera;
-	}
-
-	private void OnEnableMouseControlCamera()
-	{
-		_isRMBPressed = true;
-
-		Cursor.lockState = CursorLockMode.Locked;
-		Cursor.visible = false;
-	}
-
-	private void OnDisableMouseControlCamera()
-	{
-		_isRMBPressed = false;
-
-		Cursor.lockState = CursorLockMode.None;
-		Cursor.visible = true;
-
-		// when mouse control is disabled, the input needs to be cleared
-		// or the last frame's input will 'stick' until the action is invoked again
-		freeLookVCam.m_XAxis.m_InputAxisValue = 0;
-		freeLookVCam.m_YAxis.m_InputAxisValue = 0;
-	}
-
-	private void OnCameraMove(Vector2 cameraMovement, bool isDeviceMouse)
-	{
-		if (isDeviceMouse && !_isRMBPressed)
-			return;
-
-		freeLookVCam.m_XAxis.m_InputAxisValue = cameraMovement.x * Time.smoothDeltaTime * speed;
-		freeLookVCam.m_YAxis.m_InputAxisValue = cameraMovement.y * Time.smoothDeltaTime * speed;
-	}
 }

--- a/UOP1_Project/Assets/Scripts/Input/Composites.meta
+++ b/UOP1_Project/Assets/Scripts/Input/Composites.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fe97e3c77cf6eb840a8251dc50f4adc4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Input/Composites/DragComposite.cs
+++ b/UOP1_Project/Assets/Scripts/Input/Composites/DragComposite.cs
@@ -1,0 +1,44 @@
+﻿using UnityEditor;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Layouts;
+using UnityEngine.InputSystem.Utilities;
+using UnityEngine.Scripting;
+
+[Preserve]
+#if UNITY_EDITOR
+[InitializeOnLoad]
+#endif
+[DisplayStringFormat("{Trigger}+{Delta}")]
+public class DragComposite : InputBindingComposite<Vector2>
+{
+	[RuntimeInitializeOnLoadMethod]
+	private static void Init() { }
+
+	static DragComposite()
+	{
+		InputSystem.RegisterBindingComposite<DragComposite>();
+	}
+
+	[InputControl(layout = "Button")]
+	public int Trigger;
+
+	[InputControl(layout = "Vector2")]
+	public int Delta;
+
+	private readonly Vector2MagnitudeComparer _comparer = new Vector2MagnitudeComparer();
+
+	public override Vector2 ReadValue(ref InputBindingCompositeContext context)
+	{
+		if (context.ReadValueAsButton(Trigger))
+		{
+			return context.ReadValue<Vector2, Vector2MagnitudeComparer>(Delta, _comparer);
+		}
+		return default;
+	}
+
+	public override float EvaluateMagnitude(ref InputBindingCompositeContext context)
+	{
+		return ReadValue(ref context).magnitude;
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Input/Composites/DragComposite.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Input/Composites/DragComposite.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36927912fa428d544aff41ea2df942bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Input/GameInput.cs
+++ b/UOP1_Project/Assets/Scripts/Input/GameInput.cs
@@ -8,10 +8,10 @@ using UnityEngine.InputSystem.Utilities;
 
 public class @GameInput : IInputActionCollection, IDisposable
 {
-	public InputActionAsset asset { get; }
-	public @GameInput()
-	{
-		asset = InputActionAsset.FromJson(@"{
+    public InputActionAsset asset { get; }
+    public @GameInput()
+    {
+        asset = InputActionAsset.FromJson(@"{
     ""name"": ""GameInput"",
     ""maps"": [
         {
@@ -71,14 +71,6 @@ public class @GameInput : IInputActionCollection, IDisposable
                     ""type"": ""Value"",
                     ""id"": ""1c4a88b5-2474-4e49-8f10-f987bde2dee0"",
                     ""expectedControlType"": ""Vector2"",
-                    ""processors"": """",
-                    ""interactions"": """"
-                },
-                {
-                    ""name"": ""MouseControlCamera"",
-                    ""type"": ""Button"",
-                    ""id"": ""3172ea7f-84a3-4236-b03d-2beae11fa2e0"",
-                    ""expectedControlType"": ""Button"",
                     ""processors"": """",
                     ""interactions"": """"
                 }
@@ -437,26 +429,37 @@ public class @GameInput : IInputActionCollection, IDisposable
                     ""isPartOfComposite"": true
                 },
                 {
-                    ""name"": """",
-                    ""id"": ""88e5a69d-cf1d-43ce-b5ab-9db67f819255"",
-                    ""path"": ""<Mouse>/delta"",
+                    ""name"": ""Mouse Drag"",
+                    ""id"": ""df73705a-d548-4197-9d01-e23af37cfdb0"",
+                    ""path"": ""Drag"",
                     ""interactions"": """",
-                    ""processors"": ""ScaleVector2"",
-                    ""groups"": ""KeyboardOrGamepad"",
+                    ""processors"": """",
+                    ""groups"": """",
                     ""action"": ""RotateCamera"",
-                    ""isComposite"": false,
+                    ""isComposite"": true,
                     ""isPartOfComposite"": false
                 },
                 {
-                    ""name"": """",
-                    ""id"": ""55713f13-8452-439f-b87e-76d9f2839d7e"",
+                    ""name"": ""Trigger"",
+                    ""id"": ""f6ff3888-74e7-4fff-8def-7b9101e7fdb5"",
                     ""path"": ""<Mouse>/rightButton"",
                     ""interactions"": """",
                     ""processors"": """",
-                    ""groups"": ""KeyboardOrGamepad"",
-                    ""action"": ""MouseControlCamera"",
+                    ""groups"": """",
+                    ""action"": ""RotateCamera"",
                     ""isComposite"": false,
-                    ""isPartOfComposite"": false
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""Delta"",
+                    ""id"": ""9357c36a-1a7c-498d-8215-d960ca191c5e"",
+                    ""path"": ""<Mouse>/delta"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""RotateCamera"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
                 }
             ]
         },
@@ -1075,279 +1078,268 @@ public class @GameInput : IInputActionCollection, IDisposable
         }
     ]
 }");
-		// Gameplay
-		m_Gameplay = asset.FindActionMap("Gameplay", throwIfNotFound: true);
-		m_Gameplay_Move = m_Gameplay.FindAction("Move", throwIfNotFound: true);
-		m_Gameplay_Jump = m_Gameplay.FindAction("Jump", throwIfNotFound: true);
-		m_Gameplay_Attack = m_Gameplay.FindAction("Attack", throwIfNotFound: true);
-		m_Gameplay_Interact = m_Gameplay.FindAction("Interact", throwIfNotFound: true);
-		m_Gameplay_Pause = m_Gameplay.FindAction("Pause", throwIfNotFound: true);
-		m_Gameplay_ExtraAction = m_Gameplay.FindAction("ExtraAction", throwIfNotFound: true);
-		m_Gameplay_RotateCamera = m_Gameplay.FindAction("RotateCamera", throwIfNotFound: true);
-		m_Gameplay_MouseControlCamera = m_Gameplay.FindAction("MouseControlCamera", throwIfNotFound: true);
-		// Menus
-		m_Menus = asset.FindActionMap("Menus", throwIfNotFound: true);
-		m_Menus_MoveSelection = m_Menus.FindAction("MoveSelection", throwIfNotFound: true);
-		m_Menus_Confirm = m_Menus.FindAction("Confirm", throwIfNotFound: true);
-		m_Menus_Cancel = m_Menus.FindAction("Cancel", throwIfNotFound: true);
-		// Dialogues
-		m_Dialogues = asset.FindActionMap("Dialogues", throwIfNotFound: true);
-		m_Dialogues_MoveSelection = m_Dialogues.FindAction("MoveSelection", throwIfNotFound: true);
-		m_Dialogues_AdvanceDialogue = m_Dialogues.FindAction("AdvanceDialogue", throwIfNotFound: true);
-	}
+        // Gameplay
+        m_Gameplay = asset.FindActionMap("Gameplay", throwIfNotFound: true);
+        m_Gameplay_Move = m_Gameplay.FindAction("Move", throwIfNotFound: true);
+        m_Gameplay_Jump = m_Gameplay.FindAction("Jump", throwIfNotFound: true);
+        m_Gameplay_Attack = m_Gameplay.FindAction("Attack", throwIfNotFound: true);
+        m_Gameplay_Interact = m_Gameplay.FindAction("Interact", throwIfNotFound: true);
+        m_Gameplay_Pause = m_Gameplay.FindAction("Pause", throwIfNotFound: true);
+        m_Gameplay_ExtraAction = m_Gameplay.FindAction("ExtraAction", throwIfNotFound: true);
+        m_Gameplay_RotateCamera = m_Gameplay.FindAction("RotateCamera", throwIfNotFound: true);
+        // Menus
+        m_Menus = asset.FindActionMap("Menus", throwIfNotFound: true);
+        m_Menus_MoveSelection = m_Menus.FindAction("MoveSelection", throwIfNotFound: true);
+        m_Menus_Confirm = m_Menus.FindAction("Confirm", throwIfNotFound: true);
+        m_Menus_Cancel = m_Menus.FindAction("Cancel", throwIfNotFound: true);
+        // Dialogues
+        m_Dialogues = asset.FindActionMap("Dialogues", throwIfNotFound: true);
+        m_Dialogues_MoveSelection = m_Dialogues.FindAction("MoveSelection", throwIfNotFound: true);
+        m_Dialogues_AdvanceDialogue = m_Dialogues.FindAction("AdvanceDialogue", throwIfNotFound: true);
+    }
 
-	public void Dispose()
-	{
-		UnityEngine.Object.Destroy(asset);
-	}
+    public void Dispose()
+    {
+        UnityEngine.Object.Destroy(asset);
+    }
 
-	public InputBinding? bindingMask
-	{
-		get => asset.bindingMask;
-		set => asset.bindingMask = value;
-	}
+    public InputBinding? bindingMask
+    {
+        get => asset.bindingMask;
+        set => asset.bindingMask = value;
+    }
 
-	public ReadOnlyArray<InputDevice>? devices
-	{
-		get => asset.devices;
-		set => asset.devices = value;
-	}
+    public ReadOnlyArray<InputDevice>? devices
+    {
+        get => asset.devices;
+        set => asset.devices = value;
+    }
 
-	public ReadOnlyArray<InputControlScheme> controlSchemes => asset.controlSchemes;
+    public ReadOnlyArray<InputControlScheme> controlSchemes => asset.controlSchemes;
 
-	public bool Contains(InputAction action)
-	{
-		return asset.Contains(action);
-	}
+    public bool Contains(InputAction action)
+    {
+        return asset.Contains(action);
+    }
 
-	public IEnumerator<InputAction> GetEnumerator()
-	{
-		return asset.GetEnumerator();
-	}
+    public IEnumerator<InputAction> GetEnumerator()
+    {
+        return asset.GetEnumerator();
+    }
 
-	IEnumerator IEnumerable.GetEnumerator()
-	{
-		return GetEnumerator();
-	}
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
 
-	public void Enable()
-	{
-		asset.Enable();
-	}
+    public void Enable()
+    {
+        asset.Enable();
+    }
 
-	public void Disable()
-	{
-		asset.Disable();
-	}
+    public void Disable()
+    {
+        asset.Disable();
+    }
 
-	// Gameplay
-	private readonly InputActionMap m_Gameplay;
-	private IGameplayActions m_GameplayActionsCallbackInterface;
-	private readonly InputAction m_Gameplay_Move;
-	private readonly InputAction m_Gameplay_Jump;
-	private readonly InputAction m_Gameplay_Attack;
-	private readonly InputAction m_Gameplay_Interact;
-	private readonly InputAction m_Gameplay_Pause;
-	private readonly InputAction m_Gameplay_ExtraAction;
-	private readonly InputAction m_Gameplay_RotateCamera;
-	private readonly InputAction m_Gameplay_MouseControlCamera;
-	public struct GameplayActions
-	{
-		private @GameInput m_Wrapper;
-		public GameplayActions(@GameInput wrapper) { m_Wrapper = wrapper; }
-		public InputAction @Move => m_Wrapper.m_Gameplay_Move;
-		public InputAction @Jump => m_Wrapper.m_Gameplay_Jump;
-		public InputAction @Attack => m_Wrapper.m_Gameplay_Attack;
-		public InputAction @Interact => m_Wrapper.m_Gameplay_Interact;
-		public InputAction @Pause => m_Wrapper.m_Gameplay_Pause;
-		public InputAction @ExtraAction => m_Wrapper.m_Gameplay_ExtraAction;
-		public InputAction @RotateCamera => m_Wrapper.m_Gameplay_RotateCamera;
-		public InputAction @MouseControlCamera => m_Wrapper.m_Gameplay_MouseControlCamera;
-		public InputActionMap Get() { return m_Wrapper.m_Gameplay; }
-		public void Enable() { Get().Enable(); }
-		public void Disable() { Get().Disable(); }
-		public bool enabled => Get().enabled;
-		public static implicit operator InputActionMap(GameplayActions set) { return set.Get(); }
-		public void SetCallbacks(IGameplayActions instance)
-		{
-			if (m_Wrapper.m_GameplayActionsCallbackInterface != null)
-			{
-				@Move.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
-				@Move.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
-				@Move.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
-				@Jump.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnJump;
-				@Jump.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnJump;
-				@Jump.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnJump;
-				@Attack.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnAttack;
-				@Attack.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnAttack;
-				@Attack.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnAttack;
-				@Interact.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnInteract;
-				@Interact.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnInteract;
-				@Interact.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnInteract;
-				@Pause.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnPause;
-				@Pause.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnPause;
-				@Pause.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnPause;
-				@ExtraAction.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnExtraAction;
-				@ExtraAction.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnExtraAction;
-				@ExtraAction.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnExtraAction;
-				@RotateCamera.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRotateCamera;
-				@RotateCamera.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRotateCamera;
-				@RotateCamera.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRotateCamera;
-				@MouseControlCamera.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMouseControlCamera;
-				@MouseControlCamera.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMouseControlCamera;
-				@MouseControlCamera.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMouseControlCamera;
-			}
-			m_Wrapper.m_GameplayActionsCallbackInterface = instance;
-			if (instance != null)
-			{
-				@Move.started += instance.OnMove;
-				@Move.performed += instance.OnMove;
-				@Move.canceled += instance.OnMove;
-				@Jump.started += instance.OnJump;
-				@Jump.performed += instance.OnJump;
-				@Jump.canceled += instance.OnJump;
-				@Attack.started += instance.OnAttack;
-				@Attack.performed += instance.OnAttack;
-				@Attack.canceled += instance.OnAttack;
-				@Interact.started += instance.OnInteract;
-				@Interact.performed += instance.OnInteract;
-				@Interact.canceled += instance.OnInteract;
-				@Pause.started += instance.OnPause;
-				@Pause.performed += instance.OnPause;
-				@Pause.canceled += instance.OnPause;
-				@ExtraAction.started += instance.OnExtraAction;
-				@ExtraAction.performed += instance.OnExtraAction;
-				@ExtraAction.canceled += instance.OnExtraAction;
-				@RotateCamera.started += instance.OnRotateCamera;
-				@RotateCamera.performed += instance.OnRotateCamera;
-				@RotateCamera.canceled += instance.OnRotateCamera;
-				@MouseControlCamera.started += instance.OnMouseControlCamera;
-				@MouseControlCamera.performed += instance.OnMouseControlCamera;
-				@MouseControlCamera.canceled += instance.OnMouseControlCamera;
-			}
-		}
-	}
-	public GameplayActions @Gameplay => new GameplayActions(this);
+    // Gameplay
+    private readonly InputActionMap m_Gameplay;
+    private IGameplayActions m_GameplayActionsCallbackInterface;
+    private readonly InputAction m_Gameplay_Move;
+    private readonly InputAction m_Gameplay_Jump;
+    private readonly InputAction m_Gameplay_Attack;
+    private readonly InputAction m_Gameplay_Interact;
+    private readonly InputAction m_Gameplay_Pause;
+    private readonly InputAction m_Gameplay_ExtraAction;
+    private readonly InputAction m_Gameplay_RotateCamera;
+    public struct GameplayActions
+    {
+        private @GameInput m_Wrapper;
+        public GameplayActions(@GameInput wrapper) { m_Wrapper = wrapper; }
+        public InputAction @Move => m_Wrapper.m_Gameplay_Move;
+        public InputAction @Jump => m_Wrapper.m_Gameplay_Jump;
+        public InputAction @Attack => m_Wrapper.m_Gameplay_Attack;
+        public InputAction @Interact => m_Wrapper.m_Gameplay_Interact;
+        public InputAction @Pause => m_Wrapper.m_Gameplay_Pause;
+        public InputAction @ExtraAction => m_Wrapper.m_Gameplay_ExtraAction;
+        public InputAction @RotateCamera => m_Wrapper.m_Gameplay_RotateCamera;
+        public InputActionMap Get() { return m_Wrapper.m_Gameplay; }
+        public void Enable() { Get().Enable(); }
+        public void Disable() { Get().Disable(); }
+        public bool enabled => Get().enabled;
+        public static implicit operator InputActionMap(GameplayActions set) { return set.Get(); }
+        public void SetCallbacks(IGameplayActions instance)
+        {
+            if (m_Wrapper.m_GameplayActionsCallbackInterface != null)
+            {
+                @Move.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
+                @Move.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
+                @Move.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
+                @Jump.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnJump;
+                @Jump.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnJump;
+                @Jump.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnJump;
+                @Attack.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnAttack;
+                @Attack.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnAttack;
+                @Attack.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnAttack;
+                @Interact.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnInteract;
+                @Interact.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnInteract;
+                @Interact.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnInteract;
+                @Pause.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnPause;
+                @Pause.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnPause;
+                @Pause.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnPause;
+                @ExtraAction.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnExtraAction;
+                @ExtraAction.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnExtraAction;
+                @ExtraAction.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnExtraAction;
+                @RotateCamera.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRotateCamera;
+                @RotateCamera.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRotateCamera;
+                @RotateCamera.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRotateCamera;
+            }
+            m_Wrapper.m_GameplayActionsCallbackInterface = instance;
+            if (instance != null)
+            {
+                @Move.started += instance.OnMove;
+                @Move.performed += instance.OnMove;
+                @Move.canceled += instance.OnMove;
+                @Jump.started += instance.OnJump;
+                @Jump.performed += instance.OnJump;
+                @Jump.canceled += instance.OnJump;
+                @Attack.started += instance.OnAttack;
+                @Attack.performed += instance.OnAttack;
+                @Attack.canceled += instance.OnAttack;
+                @Interact.started += instance.OnInteract;
+                @Interact.performed += instance.OnInteract;
+                @Interact.canceled += instance.OnInteract;
+                @Pause.started += instance.OnPause;
+                @Pause.performed += instance.OnPause;
+                @Pause.canceled += instance.OnPause;
+                @ExtraAction.started += instance.OnExtraAction;
+                @ExtraAction.performed += instance.OnExtraAction;
+                @ExtraAction.canceled += instance.OnExtraAction;
+                @RotateCamera.started += instance.OnRotateCamera;
+                @RotateCamera.performed += instance.OnRotateCamera;
+                @RotateCamera.canceled += instance.OnRotateCamera;
+            }
+        }
+    }
+    public GameplayActions @Gameplay => new GameplayActions(this);
 
-	// Menus
-	private readonly InputActionMap m_Menus;
-	private IMenusActions m_MenusActionsCallbackInterface;
-	private readonly InputAction m_Menus_MoveSelection;
-	private readonly InputAction m_Menus_Confirm;
-	private readonly InputAction m_Menus_Cancel;
-	public struct MenusActions
-	{
-		private @GameInput m_Wrapper;
-		public MenusActions(@GameInput wrapper) { m_Wrapper = wrapper; }
-		public InputAction @MoveSelection => m_Wrapper.m_Menus_MoveSelection;
-		public InputAction @Confirm => m_Wrapper.m_Menus_Confirm;
-		public InputAction @Cancel => m_Wrapper.m_Menus_Cancel;
-		public InputActionMap Get() { return m_Wrapper.m_Menus; }
-		public void Enable() { Get().Enable(); }
-		public void Disable() { Get().Disable(); }
-		public bool enabled => Get().enabled;
-		public static implicit operator InputActionMap(MenusActions set) { return set.Get(); }
-		public void SetCallbacks(IMenusActions instance)
-		{
-			if (m_Wrapper.m_MenusActionsCallbackInterface != null)
-			{
-				@MoveSelection.started -= m_Wrapper.m_MenusActionsCallbackInterface.OnMoveSelection;
-				@MoveSelection.performed -= m_Wrapper.m_MenusActionsCallbackInterface.OnMoveSelection;
-				@MoveSelection.canceled -= m_Wrapper.m_MenusActionsCallbackInterface.OnMoveSelection;
-				@Confirm.started -= m_Wrapper.m_MenusActionsCallbackInterface.OnConfirm;
-				@Confirm.performed -= m_Wrapper.m_MenusActionsCallbackInterface.OnConfirm;
-				@Confirm.canceled -= m_Wrapper.m_MenusActionsCallbackInterface.OnConfirm;
-				@Cancel.started -= m_Wrapper.m_MenusActionsCallbackInterface.OnCancel;
-				@Cancel.performed -= m_Wrapper.m_MenusActionsCallbackInterface.OnCancel;
-				@Cancel.canceled -= m_Wrapper.m_MenusActionsCallbackInterface.OnCancel;
-			}
-			m_Wrapper.m_MenusActionsCallbackInterface = instance;
-			if (instance != null)
-			{
-				@MoveSelection.started += instance.OnMoveSelection;
-				@MoveSelection.performed += instance.OnMoveSelection;
-				@MoveSelection.canceled += instance.OnMoveSelection;
-				@Confirm.started += instance.OnConfirm;
-				@Confirm.performed += instance.OnConfirm;
-				@Confirm.canceled += instance.OnConfirm;
-				@Cancel.started += instance.OnCancel;
-				@Cancel.performed += instance.OnCancel;
-				@Cancel.canceled += instance.OnCancel;
-			}
-		}
-	}
-	public MenusActions @Menus => new MenusActions(this);
+    // Menus
+    private readonly InputActionMap m_Menus;
+    private IMenusActions m_MenusActionsCallbackInterface;
+    private readonly InputAction m_Menus_MoveSelection;
+    private readonly InputAction m_Menus_Confirm;
+    private readonly InputAction m_Menus_Cancel;
+    public struct MenusActions
+    {
+        private @GameInput m_Wrapper;
+        public MenusActions(@GameInput wrapper) { m_Wrapper = wrapper; }
+        public InputAction @MoveSelection => m_Wrapper.m_Menus_MoveSelection;
+        public InputAction @Confirm => m_Wrapper.m_Menus_Confirm;
+        public InputAction @Cancel => m_Wrapper.m_Menus_Cancel;
+        public InputActionMap Get() { return m_Wrapper.m_Menus; }
+        public void Enable() { Get().Enable(); }
+        public void Disable() { Get().Disable(); }
+        public bool enabled => Get().enabled;
+        public static implicit operator InputActionMap(MenusActions set) { return set.Get(); }
+        public void SetCallbacks(IMenusActions instance)
+        {
+            if (m_Wrapper.m_MenusActionsCallbackInterface != null)
+            {
+                @MoveSelection.started -= m_Wrapper.m_MenusActionsCallbackInterface.OnMoveSelection;
+                @MoveSelection.performed -= m_Wrapper.m_MenusActionsCallbackInterface.OnMoveSelection;
+                @MoveSelection.canceled -= m_Wrapper.m_MenusActionsCallbackInterface.OnMoveSelection;
+                @Confirm.started -= m_Wrapper.m_MenusActionsCallbackInterface.OnConfirm;
+                @Confirm.performed -= m_Wrapper.m_MenusActionsCallbackInterface.OnConfirm;
+                @Confirm.canceled -= m_Wrapper.m_MenusActionsCallbackInterface.OnConfirm;
+                @Cancel.started -= m_Wrapper.m_MenusActionsCallbackInterface.OnCancel;
+                @Cancel.performed -= m_Wrapper.m_MenusActionsCallbackInterface.OnCancel;
+                @Cancel.canceled -= m_Wrapper.m_MenusActionsCallbackInterface.OnCancel;
+            }
+            m_Wrapper.m_MenusActionsCallbackInterface = instance;
+            if (instance != null)
+            {
+                @MoveSelection.started += instance.OnMoveSelection;
+                @MoveSelection.performed += instance.OnMoveSelection;
+                @MoveSelection.canceled += instance.OnMoveSelection;
+                @Confirm.started += instance.OnConfirm;
+                @Confirm.performed += instance.OnConfirm;
+                @Confirm.canceled += instance.OnConfirm;
+                @Cancel.started += instance.OnCancel;
+                @Cancel.performed += instance.OnCancel;
+                @Cancel.canceled += instance.OnCancel;
+            }
+        }
+    }
+    public MenusActions @Menus => new MenusActions(this);
 
-	// Dialogues
-	private readonly InputActionMap m_Dialogues;
-	private IDialoguesActions m_DialoguesActionsCallbackInterface;
-	private readonly InputAction m_Dialogues_MoveSelection;
-	private readonly InputAction m_Dialogues_AdvanceDialogue;
-	public struct DialoguesActions
-	{
-		private @GameInput m_Wrapper;
-		public DialoguesActions(@GameInput wrapper) { m_Wrapper = wrapper; }
-		public InputAction @MoveSelection => m_Wrapper.m_Dialogues_MoveSelection;
-		public InputAction @AdvanceDialogue => m_Wrapper.m_Dialogues_AdvanceDialogue;
-		public InputActionMap Get() { return m_Wrapper.m_Dialogues; }
-		public void Enable() { Get().Enable(); }
-		public void Disable() { Get().Disable(); }
-		public bool enabled => Get().enabled;
-		public static implicit operator InputActionMap(DialoguesActions set) { return set.Get(); }
-		public void SetCallbacks(IDialoguesActions instance)
-		{
-			if (m_Wrapper.m_DialoguesActionsCallbackInterface != null)
-			{
-				@MoveSelection.started -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnMoveSelection;
-				@MoveSelection.performed -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnMoveSelection;
-				@MoveSelection.canceled -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnMoveSelection;
-				@AdvanceDialogue.started -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnAdvanceDialogue;
-				@AdvanceDialogue.performed -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnAdvanceDialogue;
-				@AdvanceDialogue.canceled -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnAdvanceDialogue;
-			}
-			m_Wrapper.m_DialoguesActionsCallbackInterface = instance;
-			if (instance != null)
-			{
-				@MoveSelection.started += instance.OnMoveSelection;
-				@MoveSelection.performed += instance.OnMoveSelection;
-				@MoveSelection.canceled += instance.OnMoveSelection;
-				@AdvanceDialogue.started += instance.OnAdvanceDialogue;
-				@AdvanceDialogue.performed += instance.OnAdvanceDialogue;
-				@AdvanceDialogue.canceled += instance.OnAdvanceDialogue;
-			}
-		}
-	}
-	public DialoguesActions @Dialogues => new DialoguesActions(this);
-	private int m_KeyboardOrGamepadSchemeIndex = -1;
-	public InputControlScheme KeyboardOrGamepadScheme
-	{
-		get
-		{
-			if (m_KeyboardOrGamepadSchemeIndex == -1)
-				m_KeyboardOrGamepadSchemeIndex = asset.FindControlSchemeIndex("KeyboardOrGamepad");
-			return asset.controlSchemes[m_KeyboardOrGamepadSchemeIndex];
-		}
-	}
-	public interface IGameplayActions
-	{
-		void OnMove(InputAction.CallbackContext context);
-		void OnJump(InputAction.CallbackContext context);
-		void OnAttack(InputAction.CallbackContext context);
-		void OnInteract(InputAction.CallbackContext context);
-		void OnPause(InputAction.CallbackContext context);
-		void OnExtraAction(InputAction.CallbackContext context);
-		void OnRotateCamera(InputAction.CallbackContext context);
-		void OnMouseControlCamera(InputAction.CallbackContext context);
-	}
-	public interface IMenusActions
-	{
-		void OnMoveSelection(InputAction.CallbackContext context);
-		void OnConfirm(InputAction.CallbackContext context);
-		void OnCancel(InputAction.CallbackContext context);
-	}
-	public interface IDialoguesActions
-	{
-		void OnMoveSelection(InputAction.CallbackContext context);
-		void OnAdvanceDialogue(InputAction.CallbackContext context);
-	}
+    // Dialogues
+    private readonly InputActionMap m_Dialogues;
+    private IDialoguesActions m_DialoguesActionsCallbackInterface;
+    private readonly InputAction m_Dialogues_MoveSelection;
+    private readonly InputAction m_Dialogues_AdvanceDialogue;
+    public struct DialoguesActions
+    {
+        private @GameInput m_Wrapper;
+        public DialoguesActions(@GameInput wrapper) { m_Wrapper = wrapper; }
+        public InputAction @MoveSelection => m_Wrapper.m_Dialogues_MoveSelection;
+        public InputAction @AdvanceDialogue => m_Wrapper.m_Dialogues_AdvanceDialogue;
+        public InputActionMap Get() { return m_Wrapper.m_Dialogues; }
+        public void Enable() { Get().Enable(); }
+        public void Disable() { Get().Disable(); }
+        public bool enabled => Get().enabled;
+        public static implicit operator InputActionMap(DialoguesActions set) { return set.Get(); }
+        public void SetCallbacks(IDialoguesActions instance)
+        {
+            if (m_Wrapper.m_DialoguesActionsCallbackInterface != null)
+            {
+                @MoveSelection.started -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnMoveSelection;
+                @MoveSelection.performed -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnMoveSelection;
+                @MoveSelection.canceled -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnMoveSelection;
+                @AdvanceDialogue.started -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnAdvanceDialogue;
+                @AdvanceDialogue.performed -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnAdvanceDialogue;
+                @AdvanceDialogue.canceled -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnAdvanceDialogue;
+            }
+            m_Wrapper.m_DialoguesActionsCallbackInterface = instance;
+            if (instance != null)
+            {
+                @MoveSelection.started += instance.OnMoveSelection;
+                @MoveSelection.performed += instance.OnMoveSelection;
+                @MoveSelection.canceled += instance.OnMoveSelection;
+                @AdvanceDialogue.started += instance.OnAdvanceDialogue;
+                @AdvanceDialogue.performed += instance.OnAdvanceDialogue;
+                @AdvanceDialogue.canceled += instance.OnAdvanceDialogue;
+            }
+        }
+    }
+    public DialoguesActions @Dialogues => new DialoguesActions(this);
+    private int m_KeyboardOrGamepadSchemeIndex = -1;
+    public InputControlScheme KeyboardOrGamepadScheme
+    {
+        get
+        {
+            if (m_KeyboardOrGamepadSchemeIndex == -1) m_KeyboardOrGamepadSchemeIndex = asset.FindControlSchemeIndex("KeyboardOrGamepad");
+            return asset.controlSchemes[m_KeyboardOrGamepadSchemeIndex];
+        }
+    }
+    public interface IGameplayActions
+    {
+        void OnMove(InputAction.CallbackContext context);
+        void OnJump(InputAction.CallbackContext context);
+        void OnAttack(InputAction.CallbackContext context);
+        void OnInteract(InputAction.CallbackContext context);
+        void OnPause(InputAction.CallbackContext context);
+        void OnExtraAction(InputAction.CallbackContext context);
+        void OnRotateCamera(InputAction.CallbackContext context);
+    }
+    public interface IMenusActions
+    {
+        void OnMoveSelection(InputAction.CallbackContext context);
+        void OnConfirm(InputAction.CallbackContext context);
+        void OnCancel(InputAction.CallbackContext context);
+    }
+    public interface IDialoguesActions
+    {
+        void OnMoveSelection(InputAction.CallbackContext context);
+        void OnAdvanceDialogue(InputAction.CallbackContext context);
+    }
 }

--- a/UOP1_Project/Assets/Scripts/Input/InputReader.cs
+++ b/UOP1_Project/Assets/Scripts/Input/InputReader.cs
@@ -13,9 +13,7 @@ public class InputReader : ScriptableObject, GameInput.IGameplayActions, GameInp
 	public event UnityAction extraActionEvent; // Used to bring up the inventory
 	public event UnityAction pauseEvent;
 	public event UnityAction<Vector2> moveEvent;
-	public event UnityAction<Vector2, bool> cameraMoveEvent;
-	public event UnityAction enableMouseControlCameraEvent;
-	public event UnityAction disableMouseControlCameraEvent;
+	public event UnityAction<Vector2> cameraRotateEvent;
 
 	// Dialogue
 	public event UnityAction advanceDialogueEvent = delegate { };
@@ -89,22 +87,11 @@ public class InputReader : ScriptableObject, GameInput.IGameplayActions, GameInp
 
 	public void OnRotateCamera(InputAction.CallbackContext context)
 	{
-		if (cameraMoveEvent != null)
+		if (cameraRotateEvent != null)
 		{
-			cameraMoveEvent.Invoke(context.ReadValue<Vector2>(), IsDeviceMouse(context));
+			cameraRotateEvent.Invoke(context.ReadValue<Vector2>());
 		}
 	}
-
-	public void OnMouseControlCamera(InputAction.CallbackContext context)
-	{
-		if (context.phase == InputActionPhase.Performed)
-			enableMouseControlCameraEvent?.Invoke();
-
-		if (context.phase == InputActionPhase.Canceled)
-			disableMouseControlCameraEvent?.Invoke();
-	}
-
-	private bool IsDeviceMouse(InputAction.CallbackContext context) => context.control.device.name == "Mouse";
 
 	public void OnMoveSelection(InputAction.CallbackContext context)
 	{

--- a/UOP1_Project/Assets/Settings/Input/GameInput.inputactions
+++ b/UOP1_Project/Assets/Settings/Input/GameInput.inputactions
@@ -60,14 +60,6 @@
                     "expectedControlType": "Vector2",
                     "processors": "",
                     "interactions": ""
-                },
-                {
-                    "name": "MouseControlCamera",
-                    "type": "Button",
-                    "id": "3172ea7f-84a3-4236-b03d-2beae11fa2e0",
-                    "expectedControlType": "Button",
-                    "processors": "",
-                    "interactions": ""
                 }
             ],
             "bindings": [
@@ -424,26 +416,37 @@
                     "isPartOfComposite": true
                 },
                 {
-                    "name": "",
-                    "id": "88e5a69d-cf1d-43ce-b5ab-9db67f819255",
-                    "path": "<Mouse>/delta",
+                    "name": "Mouse Drag",
+                    "id": "df73705a-d548-4197-9d01-e23af37cfdb0",
+                    "path": "Drag",
                     "interactions": "",
-                    "processors": "ScaleVector2",
-                    "groups": "KeyboardOrGamepad",
+                    "processors": "",
+                    "groups": "",
                     "action": "RotateCamera",
-                    "isComposite": false,
+                    "isComposite": true,
                     "isPartOfComposite": false
                 },
                 {
-                    "name": "",
-                    "id": "55713f13-8452-439f-b87e-76d9f2839d7e",
+                    "name": "Trigger",
+                    "id": "f6ff3888-74e7-4fff-8def-7b9101e7fdb5",
                     "path": "<Mouse>/rightButton",
                     "interactions": "",
                     "processors": "",
-                    "groups": "KeyboardOrGamepad",
-                    "action": "MouseControlCamera",
+                    "groups": "",
+                    "action": "RotateCamera",
                     "isComposite": false,
-                    "isPartOfComposite": false
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Delta",
+                    "id": "9357c36a-1a7c-498d-8215-d960ca191c5e",
+                    "path": "<Mouse>/delta",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "RotateCamera",
+                    "isComposite": false,
+                    "isPartOfComposite": true
                 }
             ]
         },


### PR DESCRIPTION
Issue: #245
Forum: https://forum.unity.com/threads/mouse-pointer-erratic-behaviour.1014424/#post-6581881

The way we are currently going into and out of "rotate camera mode" via a separate right mouse button action that is _only_ for setups with a mouse is not really the best way to utilize the Input System. I'm unable to reproduce the bug on my machine, but my theory is that switching modes like this is causing the erratic mouse behavior.

A better way is to use a composite where you use the right mouse button as a trigger and output the mouse delta as the delta. Then you can set the composite as a binding of the singular camera rotate action instead of several mouse specific actions. So I've made a composite called DragComposite (I made this previously in #83, but we were unsure then if mouse drag was desired) which takes a button "trigger" and a Vector2 "delta". This is easily reused and modified.

I have also modified the CameraManager, InputReader, and TestingGrounds scene to work with these changes.

To verify:
1. Play TestingGrounds.
2. Right click and drag to rotate mouse.
