### PR TITLE
BugFix Creating new Scene (Change to ProjectSettings)

### DIFF
--- a/UOP1_Project/ProjectSettings/ProjectSettings.asset
+++ b/UOP1_Project/ProjectSettings/ProjectSettings.asset
@@ -670,10 +670,10 @@ PlayerSettings:
     m_VersionCode: 1
     m_VersionName: 
   apiCompatibilityLevel: 6
-  cloudProjectId: eadb991e-24e4-432a-9a06-35e20daca02b
+  cloudProjectId: 
   framebufferDepthMemorylessMode: 0
-  projectName: Open Project 1
-  organizationId: cirocontinisio
+  projectName: 
+  organizationId: 
   cloudEnabled: 0
   enableNativePlatformBackendsForNewInputSystem: 1
   disableOldInputManagerSupport: 1


### PR DESCRIPTION
**[for Bugfix PRs]**  
For creation new SOlocation & corresponding Scene files, demanding to add new Scene to "Scene in Build", but when I try to add Scene file (at Build Setting), I receive message "Unable to access service".

This forum thread [linked to an issue](https://forum.unity.com/threads/creating-new-scene.1015867/#post-6585751).
I resolve this issue:
- Made new Link to Services and create new Unity Project ID
- After that I'm unlink the Project from Unity Services and made commit based on changed file (UOP1_Project\ProjectSettings\ProjectSettings.asset)

How can it be verified that the issue has actually been resolved?  
After that all work fine, If you return to prev file version the problem is return.