### PR TITLE
Decouple CameraManager and SpawnSystem

### DIFF
--- a/UOP1_Project/Assets/Prefabs/GameplayEssentials/CameraSystem.prefab
+++ b/UOP1_Project/Assets/Prefabs/GameplayEssentials/CameraSystem.prefab
@@ -729,6 +729,8 @@ MonoBehaviour:
   mainCamera: {fileID: 8745341642014614481}
   freeLookVCam: {fileID: 8745341641394998849}
   speed: 2
+  _frameObjectChannel: {fileID: 11400000, guid: 2723b3f59f7ede3498fe7e385d2bb6ee,
+    type: 2}
 --- !u!1 &8745341641394998848
 GameObject:
   m_ObjectHideFlags: 0

--- a/UOP1_Project/Assets/Prefabs/GameplayEssentials/SpawnSystem.prefab
+++ b/UOP1_Project/Assets/Prefabs/GameplayEssentials/SpawnSystem.prefab
@@ -47,9 +47,10 @@ MonoBehaviour:
   _defaultSpawnIndex: 0
   _playerPrefab: {fileID: 5557640735889932260, guid: 062b3805bf6784e4d9c599ee60eaa002,
     type: 3}
-  _cameraManager: {fileID: 0}
   _spawnLocations:
   - {fileID: 2125786286893897154}
+  _frameObjectChannel: {fileID: 11400000, guid: 2723b3f59f7ede3498fe7e385d2bb6ee,
+    type: 2}
 --- !u!1 &2125786286893897213
 GameObject:
   m_ObjectHideFlags: 0

--- a/UOP1_Project/Assets/ScriptableObjects/EventChannels/FrameObjectEvent_Channel.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/EventChannels/FrameObjectEvent_Channel.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e5d62472420234949aa61408039f315b, type: 3}
+  m_Name: FrameObjectEvent_Channel
+  m_EditorClassIdentifier: 

--- a/UOP1_Project/Assets/ScriptableObjects/EventChannels/FrameObjectEvent_Channel.asset.meta
+++ b/UOP1_Project/Assets/ScriptableObjects/EventChannels/FrameObjectEvent_Channel.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2723b3f59f7ede3498fe7e385d2bb6ee
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/CameraManager.cs
+++ b/UOP1_Project/Assets/Scripts/CameraManager.cs
@@ -12,6 +12,10 @@ public class CameraManager : MonoBehaviour
 	[SerializeField, Range(1f, 5f)]
 	private float speed = default;
 
+	[Header("Listening on channels")]
+	[Tooltip("The CameraManager listens to this event, fired by objects in any scene, to adapt camera position")]
+	[SerializeField] private TransformEventChannelSO _frameObjectChannel = default;
+
 	public void SetupProtagonistVirtualCamera(Transform target)
 	{
 		freeLookVCam.Follow = target;
@@ -23,6 +27,9 @@ public class CameraManager : MonoBehaviour
 		inputReader.cameraMoveEvent += OnCameraMove;
 		inputReader.enableMouseControlCameraEvent += OnEnableMouseControlCamera;
 		inputReader.disableMouseControlCameraEvent += OnDisableMouseControlCamera;
+
+		if(_frameObjectChannel != null)
+			_frameObjectChannel.OnEventRaised += OnFrameObjectEvent;
 	}
 
 	private void OnDisable()
@@ -30,6 +37,9 @@ public class CameraManager : MonoBehaviour
 		inputReader.cameraMoveEvent -= OnCameraMove;
 		inputReader.enableMouseControlCameraEvent -= OnEnableMouseControlCamera;
 		inputReader.disableMouseControlCameraEvent -= OnDisableMouseControlCamera;
+
+		if (_frameObjectChannel != null)
+			_frameObjectChannel.OnEventRaised -= OnFrameObjectEvent;
 	}
 
 	private void OnEnableMouseControlCamera()
@@ -60,5 +70,10 @@ public class CameraManager : MonoBehaviour
 
 		freeLookVCam.m_XAxis.m_InputAxisValue = cameraMovement.x * Time.smoothDeltaTime * speed;
 		freeLookVCam.m_YAxis.m_InputAxisValue = cameraMovement.y * Time.smoothDeltaTime * speed;
+	}
+
+	private void OnFrameObjectEvent(Transform value)
+	{
+		SetupProtagonistVirtualCamera(value);
 	}
 }

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/TransformEventChannelSO.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/TransformEventChannelSO.cs
@@ -1,0 +1,17 @@
+﻿using UnityEngine.Events;
+using UnityEngine;
+
+/// <summary>
+/// This class is used for Events that have one transform argument.
+/// Example: Spawn system initializes player and fire event, where the transform is the position of player.
+/// </summary>
+
+[CreateAssetMenu(menuName = "Events/Transform Event Channel")]
+public class TransformEventChannelSO : ScriptableObject
+{
+	public UnityAction<Transform> OnEventRaised;
+	public void RaiseEvent(Transform value)
+	{
+		OnEventRaised.Invoke(value);
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/TransformEventChannelSO.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/TransformEventChannelSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5d62472420234949aa61408039f315b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/SpawnSystem.cs
+++ b/UOP1_Project/Assets/Scripts/SpawnSystem.cs
@@ -11,8 +11,8 @@ public class SpawnSystem : MonoBehaviour
 	[SerializeField] private Protagonist _playerPrefab = null;
 
 	[Header("Scene References")]
-	[SerializeField] private CameraManager _cameraManager;
 	[SerializeField] private Transform[] _spawnLocations;
+	[SerializeField] private TransformEventChannelSO _frameObjectChannel;
 
 	void Start()
 	{
@@ -37,9 +37,6 @@ public class SpawnSystem : MonoBehaviour
 	[ContextMenu("Attempt Auto Fill")]
 	private void AutoFill()
 	{
-		if (_cameraManager == null)
-			_cameraManager = FindObjectOfType<CameraManager>();
-
 		if (_spawnLocations == null || _spawnLocations.Length == 0)
 			_spawnLocations = transform.GetComponentsInChildren<Transform>(true)
 								.Where(t => t != this.transform)
@@ -49,7 +46,7 @@ public class SpawnSystem : MonoBehaviour
 	private void Spawn(int spawnIndex)
 	{
 		Transform spawnLocation = GetSpawnLocation(spawnIndex, _spawnLocations);
-		Protagonist playerInstance = InstantiatePlayer(_playerPrefab, spawnLocation, _cameraManager);
+		Protagonist playerInstance = InstantiatePlayer(_playerPrefab, spawnLocation);
 		SetupCameras(playerInstance);
 	}
 
@@ -62,7 +59,7 @@ public class SpawnSystem : MonoBehaviour
 		return spawnLocations[index];
 	}
 
-	private Protagonist InstantiatePlayer(Protagonist playerPrefab, Transform spawnLocation, CameraManager _cameraManager)
+	private Protagonist InstantiatePlayer(Protagonist playerPrefab, Transform spawnLocation)
 	{
 		if (playerPrefab == null)
 			throw new Exception("Player Prefab can't be null.");
@@ -74,7 +71,8 @@ public class SpawnSystem : MonoBehaviour
 
 	private void SetupCameras(Protagonist player)
 	{
-		player.gameplayCamera = _cameraManager.mainCamera.transform;
-		_cameraManager.SetupProtagonistVirtualCamera(player.transform);
+		//TODO: update this hacky assignment of mainCamera
+		player.gameplayCamera = UnityEngine.Object.FindObjectOfType<CameraManager>().mainCamera.transform;
+		_frameObjectChannel.RaiseEvent(player.transform);
 	}
 }


### PR DESCRIPTION
Card: https://open.codecks.io/unity-open-project-1/decks/15-code/card/194-decouple-cameramanager-and-spawnsystem
Forum: https://forum.unity.com/threads/decouple-cameramanager-and-spawnsystem-card-194.1016932/

Adapted the changes described on the card: Created Event channel for transform type, `eventChannelSO`, linked all together (`cameraManager`--->`eventChannelSO`<---`spawnSystem`) and raising/receiving the event with transform data.

This way the `cameraManager` should be decoupled out of `spawnSystem`.

----

When removed the old code, I've found there is one more reference to `cameraManager` in `spawnSystem`, when we assign this camera to `Protagonist`:

SpawnSystem.cs
```Csharp
private void SetupCameras(Protagonist player)
{
    player.gameplayCamera = _cameraManager.mainCamera.transform; //<======== this line
    _cameraManager.SetupProtagonistVirtualCamera(player.transform);
}
```
---

**What is the correct way to assign this camera reference to `Protagonist`?**