### PR TITLE
Feature/code: Editor for ScriptableObject with events

### DIFF
--- a/UOP1_Project/Assets/Scripts/Editor/ScriptableObjectHelper.cs
+++ b/UOP1_Project/Assets/Scripts/Editor/ScriptableObjectHelper.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using UnityEngine;
+
+public static class ScriptableObjectHelper
+{
+	public static void GenerateButtonsForEvents<T>(UnityEngine.Object target)
+		where T : ScriptableObject
+	{
+		var targetIr = target as T;
+		if (targetIr != null)
+		{
+			var typeIr = targetIr.GetType();
+			var events = typeIr.GetEvents();
+
+			foreach (var ev in events)
+			{
+				if (GUILayout.Button(ev.Name))
+				{
+					//Delegates doesn't support direct access to RaiseMethod, must use backing field
+					// https://stackoverflow.com/questions/14885325/eventinfo-getraisemethod-always-null
+					// https://social.msdn.microsoft.com/Forums/vstudio/en-US/44b0d573-5c53-47b0-8e85-6056cbae95b0/raising-an-event-via-reflection
+
+					var eventDelagate = typeIr.GetField(ev.Name, System.Reflection.BindingFlags.Instance |
+																 System.Reflection.BindingFlags.NonPublic)
+											 ?.GetValue(targetIr) as MulticastDelegate;
+					try
+					{
+						eventDelagate?.DynamicInvoke();
+					}
+					catch
+					{
+						Debug.LogWarning($"Event '{ev.Name}' requires some arguments which weren't provided. Delegate cannot be invoked directly from UI.");
+					}
+				}
+			}
+		}
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Editor/ScriptableObjectHelper.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Editor/ScriptableObjectHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0a7eba3a614f3d74fb12d27b80cd0597
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Input/Editor.meta
+++ b/UOP1_Project/Assets/Scripts/Input/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8aed24cb0c323134e96fb92cecbeafc4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Input/Editor/InputReaderEditor.cs
+++ b/UOP1_Project/Assets/Scripts/Input/Editor/InputReaderEditor.cs
@@ -1,0 +1,16 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+[CustomEditor(typeof(InputReader))]
+public class InputReaderEditor : Editor
+{
+	public override void OnInspectorGUI()
+	{
+		DrawDefaultInspector();
+
+		if (!Application.isPlaying)
+			return;
+
+		ScriptableObjectHelper.GenerateButtonsForEvents<InputReader>(target);
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Input/Editor/InputReaderEditor.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Input/Editor/InputReaderEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e46e2d2cecfc354a8ac70cae65b2343
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added editor for ScriptableObject with events. It allows to automatically show buttons for each event and raise it. Currently it is hooked only on the input SO (so on `InputReaderSO`), but can be attached simply to any other SO and allows user to invoke events from UI where argument are not needed.

I've used reflection to check the SO for event and via backing field they're invoked.

No forum or card link.

![image](https://user-images.githubusercontent.com/2912979/101292808-0a66ad00-3812-11eb-89bb-3edb35136e6d.png)
