### PR TITLE
Added small internal cooldown to the PlayLandParticlesAction StateAction

### DIFF
--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/PlayLandParticlesActionSO.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/PlayLandParticlesActionSO.cs
@@ -10,6 +10,9 @@ public class PlayLandParticlesAction : StateAction
 	//Component references
 	private DustParticlesController _dustController;
 
+	private float _coolDown = 0.3f;
+	private float t = 0f;
+
 	public override void Awake(StateMachine stateMachine)
 	{
 		_dustController = stateMachine.GetComponent<DustParticlesController>();
@@ -17,8 +20,20 @@ public class PlayLandParticlesAction : StateAction
 
 	public override void OnStateExit()
 	{
-		_dustController.PlayLandParticles();
+		PlayLandParticles();
 	}
 
-	public override void OnUpdate() { }
+	private void PlayLandParticles()
+	{
+		if (Time.time >= t + _coolDown)
+		{
+			_dustController.PlayLandParticles();
+			t = Time.time;
+		}	
+	}
+
+	public override void OnUpdate()
+	{
+		
+	}
 }

--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/PlayLandParticlesActionSO.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/PlayLandParticlesActionSO.cs
@@ -20,20 +20,12 @@ public class PlayLandParticlesAction : StateAction
 
 	public override void OnStateExit()
 	{
-		PlayLandParticles();
-	}
-
-	private void PlayLandParticles()
-	{
 		if (Time.time >= t + _coolDown)
 		{
 			_dustController.PlayLandParticles();
 			t = Time.time;
-		}	
+		}
 	}
-
-	public override void OnUpdate()
-	{
-		
-	}
+	
+	public override void OnUpdate() { }
 }


### PR DESCRIPTION
Addressing this open ticket:
https://open.codecks.io/unity-open-project-1/decks/15-code/card/18k-avoid-spamming-particles-on-sliding

Added a small solution to LandParticle Visuals being spammed when the state machine rapidly switches between the sliding and idle state, which was shown to happen in the ticket above.

After this change, Whenever the PlayLandParticlesAction is exited by the state machine, it checks if total elapsed time is greater then the total elapsed time of the last particle call + a small amount.

If so, only then do we tell the DustParticleController to play, and we also set the new time to beat to be the current time.