### PR TITLE
Create custom base editor for custom inspector

### DIFF
--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/Editor/AnimatorParameterActionSOEditor.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/Editor/AnimatorParameterActionSOEditor.cs
@@ -3,10 +3,12 @@ using UnityEngine;
 using UOP1.StateMachine;
 
 [CustomEditor(typeof(AnimatorParameterActionSO)), CanEditMultipleObjects]
-public class AnimatorParameterActionSOEditor : UnityEditor.Editor
+public class AnimatorParameterActionSOEditor : CustomBaseEditor
 {
 	public override void OnInspectorGUI()
 	{
+		DrawNonEdtiableScriptReference<AnimatorParameterActionSO>();
+
 		serializedObject.Update();
 
 		EditorGUILayout.PropertyField(serializedObject.FindProperty("whenToRun"));

--- a/UOP1_Project/Assets/Scripts/Editor/CustomBaseEditor.cs
+++ b/UOP1_Project/Assets/Scripts/Editor/CustomBaseEditor.cs
@@ -1,0 +1,28 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// Custom base editor class. Inherited from Editor class.
+/// Contains handy method to use.
+/// </summary>
+public class CustomBaseEditor : Editor
+{
+	/// <summary>
+	/// Draw reference information about script being edited.
+	/// </summary>
+	/// <typeparam name="T">Inspected type.</typeparam>
+	public void DrawNonEdtiableScriptReference<T>() where T : Object
+	{
+		//Make GUI not editable.
+		GUI.enabled = false;
+
+		//Draw reference information about script being edited.
+		if (typeof(ScriptableObject).IsAssignableFrom(typeof(T)))
+			EditorGUILayout.ObjectField("Script", MonoScript.FromScriptableObject((ScriptableObject)target), typeof(T), false);
+		else if (typeof(MonoBehaviour).IsAssignableFrom(typeof(T)))
+			EditorGUILayout.ObjectField("Script", MonoScript.FromMonoBehaviour((MonoBehaviour)target), typeof(T), false);
+
+		//Make GUI editable. 
+		GUI.enabled = true;
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Editor/CustomBaseEditor.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Editor/CustomBaseEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fdbc89f1f51984e49a0d6742a3bb776d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Editor/GameSceneSOEditor.cs
+++ b/UOP1_Project/Assets/Scripts/Editor/GameSceneSOEditor.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 
 [CustomEditor(typeof(GameSceneSO), true)]
-public class GameSceneSOEditor : Editor
+public class GameSceneSOEditor : CustomBaseEditor
 {
 	private const string NO_SCENES_WARNING = "There is no Scene associated to this location yet. Add a new scene with the dropdown below";
 	private GUIStyle _headerLabelStyle;
@@ -24,12 +24,7 @@ public class GameSceneSOEditor : Editor
 
 	public override void OnInspectorGUI()
 	{
-		//Make GUI not editable.
-		GUI.enabled = false;
-		//Draw reference information about script being edited.
-		EditorGUILayout.ObjectField("Script", MonoScript.FromScriptableObject((GameSceneSO)target), typeof(GameSceneSO), false);
-		//Make GUI editable.
-		GUI.enabled = true;
+		DrawNonEdtiableScriptReference<GameSceneSO>();
 
 		serializedObject.Update();
 		EditorGUILayout.LabelField("Scene information", _headerLabelStyle);


### PR DESCRIPTION
Proposition from Ciro in: https://github.com/UnityTechnologies/open-project-1/pull/258
Create base editor class that contain handy methods to use. 
Make things easier and no more writing repetitive code.

For now, it only contain:
- Draw Non Editable Script Reference()
![image](https://user-images.githubusercontent.com/57592497/102000793-7f0f7f00-3d1d-11eb-9426-b8e281fae7f2.png)
![image](https://user-images.githubusercontent.com/57592497/102000826-ea595100-3d1d-11eb-9892-c94e71af0002.png)

This PR already implemented to some editor that needed it (no reference to the script):
- GameSceneSO
- AnimatorParameterActionSO

there are actually more:
- TransitionTableEditor
- StateEditor

But for some reason, it can't inherit from the CustomBaseEditor class. Maybe because they are using internal?
