### PR TITLE
Control size of landing particles based on fall distance

### DIFF
--- a/UOP1_Project/Assets/Prefabs/Characters/PigChef.prefab
+++ b/UOP1_Project/Assets/Prefabs/Characters/PigChef.prefab
@@ -320,6 +320,7 @@ MonoBehaviour:
   extraActionInput: 0
   movementInput: {x: 0, y: 0, z: 0}
   movementVector: {x: 0, y: 0, z: 0}
+  isRunning: 0
 --- !u!114 &6243045328629046901
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4632,6 +4633,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: LandingParticle
+      objectReference: {fileID: 0}
+    - target: {fileID: 8442424470799517435, guid: 2a17d00f8cddbf44ea0f55e00cbc97e9,
+        type: 3}
+      propertyPath: InitialModule.startSize.scalar
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8442424470799517435, guid: 2a17d00f8cddbf44ea0f55e00cbc97e9,
+        type: 3}
+      propertyPath: InitialModule.startSize.minScalar
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 8442424470799517435, guid: 2a17d00f8cddbf44ea0f55e00cbc97e9,
+        type: 3}
+      propertyPath: EmissionModule.m_Bursts.Array.data[0].countCurve.scalar
+      value: 7
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2a17d00f8cddbf44ea0f55e00cbc97e9, type: 3}

--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/PlayLandParticlesActionSO.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/PlayLandParticlesActionSO.cs
@@ -9,20 +9,36 @@ public class PlayLandParticlesAction : StateAction
 {
 	//Component references
 	private DustParticlesController _dustController;
+	private Transform _transform;
 
 	private float _coolDown = 0.3f;
 	private float t = 0f;
 
+	private float _fallStartY = 0;
+	private float _fallEndY = 0;
+	private float _maxFallDistance = 4; //Used to adjust particle emission intensity
+
 	public override void Awake(StateMachine stateMachine)
 	{
 		_dustController = stateMachine.GetComponent<DustParticlesController>();
+		_transform = stateMachine.transform;
+	}
+
+	public override void OnStateEnter()
+	{
+		_fallStartY = _transform.position.y;
 	}
 
 	public override void OnStateExit()
 	{
+		_fallEndY = _transform.position.y;
+		float dY = _fallStartY - _fallEndY;
+		float fallIntensity = Mathf.InverseLerp(0, _maxFallDistance, dY);
+
 		if (Time.time >= t + _coolDown)
 		{
-			_dustController.PlayLandParticles();
+			//_dustController.PlayLandParticles();
+			_dustController.PlayLandParticles(fallIntensity);
 			t = Time.time;
 		}
 	}

--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/PlayLandParticlesActionSO.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/PlayLandParticlesActionSO.cs
@@ -32,7 +32,7 @@ public class PlayLandParticlesAction : StateAction
 	public override void OnStateExit()
 	{
 		_fallEndY = _transform.position.y;
-		float dY = _fallStartY - _fallEndY;
+		float dY = Mathf.Abs(_fallStartY - _fallEndY);
 		float fallIntensity = Mathf.InverseLerp(0, _maxFallDistance, dY);
 
 		if (Time.time >= t + _coolDown)

--- a/UOP1_Project/Assets/Scripts/Effects/DustParticlesController.cs
+++ b/UOP1_Project/Assets/Scripts/Effects/DustParticlesController.cs
@@ -30,4 +30,37 @@ public class DustParticlesController : MonoBehaviour
 	{
 		_landParticles.Play();
 	}
+
+	public void PlayLandParticles(float intensity)
+	{
+		// make sure intensity is always between 0 and 1
+		intensity = Mathf.Clamp01(intensity);
+
+		var main = _landParticles.main;
+		var origCurve = main.startSize; //save original curve to be assigned back to particle system
+		ParticleSystem.MinMaxCurve newCurve = main.startSize; //Make a new minMax curve and make our changes to the new copy
+
+		float minSize = newCurve.constantMin;
+		float maxSize = newCurve.constantMax;
+
+		// use the intensity to change the maximum size of the particle curve
+		newCurve.constantMax = Mathf.Lerp(minSize, maxSize, intensity);
+		main.startSize = newCurve;
+
+		_landParticles.Play();
+
+		// Put the original startSize back where you found it
+		StartCoroutine(ResetMinMaxCurve(_landParticles, origCurve));
+	}
+
+	private IEnumerator ResetMinMaxCurve(ParticleSystem ps, ParticleSystem.MinMaxCurve curve)
+	{
+		while (ps.isEmitting)
+		{
+			yield return null;
+		}
+
+		var main = ps.main;
+		main.startSize = curve;
+	}
 }


### PR DESCRIPTION
https://forum.unity.com/threads/puff-of-dust-effects.1002936/#post-6638764
I picked up on this issue through the Codecks card shown below. The forum thread for the puff effects hadn't addressed the card so I got to work on the solution. 
![image](https://user-images.githubusercontent.com/25065486/102691137-f0dd4200-41cf-11eb-8574-8e82ce70fb58.png)

**The Solution**
I made an overload of the existing method `PlayLandParticles` that takes an argument called "intensity". I then rigged the `PlayLandParticlesActionsSO` to call the method with the intensity argument. The intensity is calculated based on how far the player fell during the State it was in. Since that StateAction is only called during the Jump_Decending State, the fall distance is always positive (but I still took the absolute value for safety).

As brought up by @ciro-unity in the [forum thread](https://forum.unity.com/threads/puff-of-dust-effects.1002936/#post-6638764), the particle effect's MinMaxCurve is reset using a coroutine. This was a work-around since resetting the curve just after calling `_landingParticles.Play()` was playing the effect with the original curve, not the new one. Another reason this was done was to retain the particle effect's settings in the Unity Editor instead of overwriting them with every jump. 

**Example of a short fall**
![short-fall-before](https://user-images.githubusercontent.com/25065486/102691945-ca220a00-41d5-11eb-9650-8a3cd6250013.png)
![short-fall-before-particleSize](https://user-images.githubusercontent.com/25065486/102691952-d1491800-41d5-11eb-9bca-13a5dfdab648.png)
![short-fall-after](https://user-images.githubusercontent.com/25065486/102691954-d908bc80-41d5-11eb-9864-cab5c9686a20.png)
![short-fall-after-particleSize](https://user-images.githubusercontent.com/25065486/102691955-da39e980-41d5-11eb-8e1a-6dcb631a2a48.png)

Just after the particle effect is finished playing, the `startSize` returns back to how it was set in the Unity Editor before the fall.
![short-fall-way after-particleSize](https://user-images.githubusercontent.com/25065486/102692050-8085ef00-41d6-11eb-8ed0-d8dc39a906fd.png)


**Example of a high fall**
![high-fall-before](https://user-images.githubusercontent.com/25065486/102691966-ed4cb980-41d5-11eb-82b7-7c54f67bb30d.png)
![high-fall-before-particleSize](https://user-images.githubusercontent.com/25065486/102691968-ee7de680-41d5-11eb-8ca4-01d181da92e7.png)
![high-fall-after](https://user-images.githubusercontent.com/25065486/102691971-efaf1380-41d5-11eb-8a6a-dc2fe4d20df5.png)
![high-fall-after-particleSize](https://user-images.githubusercontent.com/25065486/102691972-f0e04080-41d5-11eb-8e24-62b0cda33837.png)

The fall is so high that the intensity is 1. So the startSize maximum value is unchanged.

**Conclusion**
Please let me know if there is anything else I can do to improve this solution. Also this is my first ever PR, so please let me know how I could improve for future reference. Thank you very much in advance! 