### PR TITLE
Improvement "Editor window to quickly open scenes" task #267

### DIFF
--- a/UOP1_Project/Assets/Scripts/Editor/ReadOnlyPropertyDrawer.cs
+++ b/UOP1_Project/Assets/Scripts/Editor/ReadOnlyPropertyDrawer.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Events;
+
+[CustomPropertyDrawer(typeof(ReadOnlyAttribute))]
+public class ReadOnlyDrawer : PropertyDrawer
+{
+	public override float GetPropertyHeight(SerializedProperty property,
+											GUIContent label)
+	{
+		return EditorGUI.GetPropertyHeight(property, label, true);
+	}
+
+	public override void OnGUI(Rect position,
+							   SerializedProperty property,
+							   GUIContent label)
+	{
+		
+		GUI.enabled = false;
+		EditorGUI.PropertyField(position, property, label, false);
+		GUI.enabled = true;
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Editor/ReadOnlyPropertyDrawer.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Editor/ReadOnlyPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 24a1554d2dbf8ef41962e5743c4a58f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/EditorTools/SceneAccessSOEditor.cs
+++ b/UOP1_Project/Assets/Scripts/EditorTools/SceneAccessSOEditor.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+using UnityEngine.Events;
+
+[CustomEditor(typeof(SceneAccessHolderSO))]
+public class SceneAccessSOEditor : Editor
+{
+	public static event System.Action OnChangeSO;
+
+	public override void OnInspectorGUI()
+	{
+		EditorGUI.BeginChangeCheck();
+
+		// Show default inspector property editor
+		DrawDefaultInspector();
+
+		if (EditorGUI.EndChangeCheck())
+		{
+			OnChangeSO?.Invoke();
+			//Other variant to send meassage from  SceneAccessSOEditor to SceneAccessTool
+			//SceneAccessTool.action?.Invoke();
+		}
+	}
+}

--- a/UOP1_Project/Assets/Scripts/EditorTools/SceneAccessSOEditor.cs.meta
+++ b/UOP1_Project/Assets/Scripts/EditorTools/SceneAccessSOEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45e2f2d40105d8243b9e852748b4abf0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/EditorTools/SceneAccessTool.cs
+++ b/UOP1_Project/Assets/Scripts/EditorTools/SceneAccessTool.cs
@@ -5,60 +5,105 @@ using UnityEditorInternal;
 using UnityEditor.SceneManagement;
 using System.Collections.Generic;
 using System.Linq;
+using System;
+
+[Serializable] public enum Layout { List, Grid }
 
 public class SceneAccessTool : EditorWindow, IHasCustomMenu
 {
 	private SceneAccessHolderSO _inspected;
 	private SerializedObject _serializedObject;
 	private Editor _sceneAccessHolderSOEditor;
-	public enum Layout { List, Grid }
-	private Layout _layout;
+
+	//Variables for store the style & layout for GUI Button in case of use the Grid Layout for SceneAccessTool
+	private GUIStyle styleCustomButton;
+	private const int gridSize = 48;
+	private GUILayoutOption[] layoutOptionsCustomButton; 
+
+	private Layout _layout = Layout.List;
 	private bool _showOptions = false;
 	private bool _editMode = false;
 	private ReorderableList list;
 
+	//Other variant to send meassage from  SceneAccessSOEditor to SceneAccessTool
+	//public static Action action;
+
 	private void OnEnable()
 	{
-
 		_inspected = Resources.Load<SceneAccessHolderSO>("SceneAccessHolder");
-		SetUpList();
-	}
-	private void SetUpList()
-	{
+
+		if (_inspected != null)
+			SetParametersSceneAccessToolFromSO();
+		else
+			{
+				Debug.Log("Resource \"SceneAccessHolder\" not found, Created new");
+				_inspected = CreateInstance<SceneAccessHolderSO>();
+				AssetDatabase.CreateAsset(_inspected, "Assets/ScriptableObjects/SceneData/Resources/SceneAccessHolder.asset");
+				AssetDatabase.SaveAssets();
+				PopulateSceneList(true);
+			}
+		
 		_serializedObject = new SerializedObject(_inspected);
-
-		if (_editMode)
-		{
-			list = new ReorderableList(_serializedObject,
-				_serializedObject.FindProperty("sceneList"),
-				true, false, false, false);
-			list.drawElementCallback =
-				(Rect rect, int index, bool isActive, bool isFocused) =>
-				{
-					var element = list.serializedProperty.GetArrayElementAtIndex(index);
-					rect.y += 2;
-					EditorGUI.PropertyField(
-						new Rect(rect.x, rect.y, rect.width - 30, EditorGUIUtility.singleLineHeight),
-						element.FindPropertyRelative("name"), GUIContent.none);
-
-					EditorGUI.PropertyField(
-						new Rect(rect.x + rect.width - 25, rect.y, 25, EditorGUIUtility.singleLineHeight),
-						element.FindPropertyRelative("visible"), GUIContent.none);
-				};
-		}
+		CreateSceneListInEditMode();
+		SceneAccessSOEditor.OnChangeSO += SceneAccessSOEditor_OnChangeSO;
+		//action = () => SceneAccessSOEditor_OnChangeSO();
 	}
+
+	private void SetParametersSceneAccessToolFromSO()
+	{
+		_showOptions = _inspected.showOptions;
+		_editMode = _inspected.editMode;
+		_layout = _inspected.sceneAccessLayout;
+	}
+
+	private void SceneAccessSOEditor_OnChangeSO()
+	{
+		SetParametersSceneAccessToolFromSO();
+		Repaint();
+	}
+
 	[MenuItem("Tools/SceneAccessTool")]
 	public static void ShowWindow()
 	{
+		
 		GetWindow<SceneAccessTool>("SceneAccessTool");
 	}
+
 	private void OnGUI()
 	{
+		//Debug.Log("Current detected event: " + Event.current);
+		//Set style & layout for GUI Button in case of use the Grid Layout for SceneAccessTool
+		// new GUIStyle("button") create the new new GUIStyle base on active GUISkin, which exist only in OnGUI()
+		styleCustomButton = new GUIStyle("button")
+		{
+			fontSize = 10,
+			alignment = TextAnchor.UpperLeft,
+			wordWrap = true
+		};
+		layoutOptionsCustomButton = new GUILayoutOption[]
+		{
+					GUILayout.Width(gridSize),
+					GUILayout.Height(gridSize)
+		};
+
 		if (_inspected != null)
 		{
+			_serializedObject.Update();
 			if (_showOptions)
 				ShowOptions();
-			ShowSceneList();
+
+			if (_editMode)
+			{
+				//Show created early the SceneListInEditMode
+				list.DoLayoutList();
+			}
+			else
+				ShowSceneListInViewMode();
+			_serializedObject.ApplyModifiedProperties();
+		}
+		else
+		{
+			throw new NotImplementedException("Resource \"SceneAccessHolder\" is absent");
 		}
 	}
 
@@ -79,81 +124,100 @@ public class SceneAccessTool : EditorWindow, IHasCustomMenu
 		}
 		GUILayout.EndHorizontal();
 	}
-	public void ShowSceneList()
+	public void ShowSceneListInViewMode()
 	{
-		if (_editMode)
+		if (_layout == Layout.List)
 		{
-			_serializedObject.Update();
-			list.DoLayoutList();
-			_serializedObject.ApplyModifiedProperties();
+			for (int i = 0; i < _inspected.sceneList.Count; i++)
+			{
+				var sceneItem = _inspected.sceneList[i];
+				if (!sceneItem.visible)
+				{
+					continue;
+				}
+				if (GUILayout.Button(sceneItem.name))
+				{
+					EditorSceneManager.OpenScene(sceneItem.path);
+				}
+			}
 		}
 		else
 		{
-			if (_layout == Layout.List)
+			int widthCount = gridSize;
+			GUILayout.BeginHorizontal();
+			for (int i = 0; i < _inspected.sceneList.Count; i++)
 			{
-				for (int i = 0; i < _inspected.sceneList.Count; i++)
+				var sceneItem = _inspected.sceneList[i];
+				if (!sceneItem.visible)
 				{
-					var sceneItem = _inspected.sceneList[i];
-					if (!sceneItem.visible)
-					{
-						continue;
-					}
-					if (GUILayout.Button(sceneItem.name))
-					{
-						EditorSceneManager.OpenScene(sceneItem.path);
-					}
-				}
-			}
-			else
-			{
-				int gridSize = 48;
-				int widthCount = gridSize;
-				GUILayout.BeginHorizontal();
-				for (int i = 0; i < _inspected.sceneList.Count; i++)
-				{
-					var sceneItem = _inspected.sceneList[i];
-					if (!sceneItem.visible)
-					{
-						continue;
-					}
-
-					GUIStyle customButton = new GUIStyle("button");
-					customButton.fontSize = 10;
-					customButton.alignment = TextAnchor.UpperLeft;
-					customButton.wordWrap = true;
-					GUIContent guiContent = new GUIContent(sceneItem.name);
-					if (GUILayout.Button(
-						guiContent,
-						customButton,
-						GUILayout.Width(gridSize),
-						GUILayout.Height(gridSize)))
-					{
-						EditorSceneManager.OpenScene(sceneItem.path);
-					}
-
-					widthCount += gridSize + 4;
-
-					if (widthCount > position.width)
-					{
-						GUILayout.EndHorizontal();
-						GUILayout.BeginHorizontal();
-						widthCount = gridSize;
-					}
+					continue;
 				}
 
-				GUILayout.EndHorizontal();
+				//GUIContent guiContent = new GUIContent(sceneItem.name);
+				if (GUILayout.Button(
+					new GUIContent(sceneItem.name),
+					styleCustomButton,
+					//GUILayout.Width(gridSize),
+					//GUILayout.Height(gridSize)
+					layoutOptionsCustomButton))
+				{
+					EditorSceneManager.OpenScene(sceneItem.path);
+				}
+
+				widthCount += gridSize + 4;
+
+				if (widthCount > position.width)
+				{
+					GUILayout.EndHorizontal();
+					GUILayout.BeginHorizontal();
+					widthCount = gridSize;
+				}
 			}
 
+			GUILayout.EndHorizontal();
 		}
+	}
+
+	public void CreateSceneListInEditMode()
+	{
+		//if (_editMode)
+		//{
+		//	_serializedObject.Update();
+		//	list?.DoLayoutList();
+		//	_serializedObject.ApplyModifiedProperties();
+		//}
+
+		//_serializedObject.Update();
+		//_serializedObject = new SerializedObject(_inspected);
+
+		list = new ReorderableList(_serializedObject,
+			_serializedObject.FindProperty("sceneList"),
+			true, false, false, false);
+		list.drawElementCallback =
+			(Rect rect, int index, bool isActive, bool isFocused) =>
+			{
+				var element = list.serializedProperty.GetArrayElementAtIndex(index);
+				rect.y += 2;
+				EditorGUI.PropertyField(
+					new Rect(rect.x, rect.y, rect.width - 30, EditorGUIUtility.singleLineHeight),
+					element.FindPropertyRelative("name"), GUIContent.none);
+
+				EditorGUI.PropertyField(
+					new Rect(rect.x + rect.width - 25, rect.y, 25, EditorGUIUtility.singleLineHeight),
+					element.FindPropertyRelative("visible"), GUIContent.none);
+			};
+		//_serializedObject.Update();
+		//list.DoLayoutList();
+		//_serializedObject.ApplyModifiedProperties();
 	}
 
 	/// <summary>
 	/// Find all scenes in the project and put them in the list
 	/// </summary>
-	private void PopulateSceneList()
+	private void PopulateSceneList(bool IsNewSceneAccessHolder = false)
 	{
-		EditorBuildSettingsScene[] currentScenes = EditorBuildSettings.scenes;
-		EditorBuildSettingsScene[] filteredScenes = currentScenes.Where(ebss => File.Exists(ebss.path)).ToArray();
+		//EditorBuildSettingsScene[] currentScenes = EditorBuildSettings.scenes;
+		EditorBuildSettingsScene[] filteredScenes = EditorBuildSettings.scenes.Where(ebss => File.Exists(ebss.path)).ToArray();
 		List<SceneAccessHolderSO.SceneInfo> allScene = new List<SceneAccessHolderSO.SceneInfo>();
 		for (int i = 0; i < filteredScenes.Length; i++)
 		{
@@ -165,20 +229,26 @@ public class SceneAccessTool : EditorWindow, IHasCustomMenu
 					visible = true
 				});
 		}
-		//add the new scenes
-		foreach (SceneAccessHolderSO.SceneInfo sceneInfo in allScene)
+		if (IsNewSceneAccessHolder)
+			foreach (SceneAccessHolderSO.SceneInfo sceneInfo in allScene)
+					_inspected.sceneList.Add(sceneInfo);
+		else
 		{
-			if (!_inspected.sceneList.Contains(sceneInfo))
+			//add the new scenes
+			foreach (SceneAccessHolderSO.SceneInfo sceneInfo in allScene)
 			{
-				_inspected.sceneList.Add(sceneInfo);
+				if (!_inspected.sceneList.Contains(sceneInfo))
+				{
+					_inspected.sceneList.Add(sceneInfo);
+				}
 			}
-		}
-		//remove the deleted scenes
-		foreach (SceneAccessHolderSO.SceneInfo sceneInfo in _inspected.sceneList.ToList())
-		{
-			if (!allScene.Contains(sceneInfo))
+			//remove the deleted scenes
+			foreach (SceneAccessHolderSO.SceneInfo sceneInfo in _inspected.sceneList.ToList())
 			{
-				_inspected.sceneList.Remove(sceneInfo);
+				if (!allScene.Contains(sceneInfo))
+				{
+					_inspected.sceneList.Remove(sceneInfo);
+				}
 			}
 		}
 	}
@@ -197,6 +267,7 @@ public class SceneAccessTool : EditorWindow, IHasCustomMenu
 	private void ToggleOptions()
 	{
 		_showOptions = !_showOptions;
+		_inspected.showOptions = _showOptions;
 	}
 	private void ToggleLayout()
 	{
@@ -208,10 +279,11 @@ public class SceneAccessTool : EditorWindow, IHasCustomMenu
 		{
 			_layout = Layout.List;
 		}
+		_inspected.sceneAccessLayout = _layout;
 	}
 	private void ToggleEditMode()
 	{
 		_editMode = !_editMode;
-		SetUpList();
+		_inspected.editMode = _editMode;
 	}
 }

--- a/UOP1_Project/Assets/Scripts/SceneManagement/ScriptableObjects/SceneAccessHolderSO.cs
+++ b/UOP1_Project/Assets/Scripts/SceneManagement/ScriptableObjects/SceneAccessHolderSO.cs
@@ -2,30 +2,8 @@
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Events;
 
-public class ReadOnlyAttribute : PropertyAttribute
-{
-
-}
-
-[CustomPropertyDrawer(typeof(ReadOnlyAttribute))]
-public class ReadOnlyDrawer : PropertyDrawer
-{
-	public override float GetPropertyHeight(SerializedProperty property,
-											GUIContent label)
-	{
-		return EditorGUI.GetPropertyHeight(property, label, true);
-	}
-
-	public override void OnGUI(Rect position,
-							   SerializedProperty property,
-							   GUIContent label)
-	{
-		GUI.enabled = false;
-		EditorGUI.PropertyField(position, property, label, true);
-		GUI.enabled = true;
-	}
-}
 /// <summary>
 /// It holds a list of scenes that's shown in the scene quick access tool
 /// </summary>
@@ -35,17 +13,32 @@ public class SceneAccessHolderSO : ScriptableObject
 	[Serializable]
 	public struct SceneInfo : IEquatable<SceneInfo>
 	{
-		[ReadOnly] public string name;
-		[ReadOnly] public string path;
+		[ReadOnly]
+		public string name;
+		[ReadOnly]
+		public string path;
 		public bool visible;
 
 		public bool Equals(SceneInfo other)
 		{
-			// Would still want to check for null etc. first.
+			// Not check on null because it's a sructure
 			return this.path == other.path;
 		}
 	}
 
+	[Header("Scene Access Tool Options")]
+	//[HideInInspector]
+	public bool showOptions;
+	//[HideInInspector]
+	public bool editMode;
+	//[HideInInspector]
+	public Layout sceneAccessLayout;
+
 	[Header("List of Scenes")]
 	public List<SceneInfo> sceneList;
+
+	public SceneAccessHolderSO()
+	{
+		this.sceneList = new List<SceneInfo>();
+	}
 }

--- a/UOP1_Project/Assets/Scripts/SceneManagement/ScriptableObjects/SceneAccessHolderSOReadOnlyAttribute.cs
+++ b/UOP1_Project/Assets/Scripts/SceneManagement/ScriptableObjects/SceneAccessHolderSOReadOnlyAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Events;
+
+public class ReadOnlyAttribute : PropertyAttribute
+{
+
+}
+

--- a/UOP1_Project/Assets/Scripts/SceneManagement/ScriptableObjects/SceneAccessHolderSOReadOnlyAttribute.cs.meta
+++ b/UOP1_Project/Assets/Scripts/SceneManagement/ScriptableObjects/SceneAccessHolderSOReadOnlyAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c87715dd0f65c8c4db5388c6c77a3cf8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/ProjectSettings/EditorBuildSettings.asset
+++ b/UOP1_Project/ProjectSettings/EditorBuildSettings.asset
@@ -21,14 +21,14 @@ EditorBuildSettings:
     path: Assets/Scenes/TestingGround.unity
     guid: 1e57caa7d7ed5e24a88cb3b5c309cc65
   - enabled: 1
-    path: Assets/Scenes/MultiSceneLoader/TestScene_03.unity
-    guid: fab260a559ee34842814a2d13b1c1798
+    path: Assets/Scenes/Examples/MultiSceneLoaderExample/TestScene_01.unity
+    guid: 77ab3eaf737d2364a95cff0c147f24c2
   - enabled: 1
-    path: Assets/Scenes/MultiSceneLoader/TestScene_02.unity
-    guid: 63d182036357bd94fb0fffb5af3736c0
+    path: Assets/Scenes/Examples/MultiSceneLoaderExample/TestScene_02.unity
+    guid: 1f367db9e9a4e7a41bcdd51e6e0b1557
   - enabled: 1
-    path: Assets/Scenes/MultiSceneLoader/TestScene_01.unity
-    guid: 9bea58aee7d47cd45b9cc32b07287fcb
+    path: Assets/Scenes/Examples/MultiSceneLoaderExample/TestScene_03.unity
+    guid: de16b4558b8e48b4b89f9d654f3977d3
   m_configObjects:
     com.unity.addressableassets: {fileID: 11400000, guid: 758daf1c1b96e4978a5b9b3f5815abf1,
       type: 2}


### PR DESCRIPTION
[forum thread](https://forum.unity.com/threads/editor-window-to-open-scenes.1019986/) linked to this PR  

this PR update & improve early merged [PR](https://github.com/UnityTechnologies/open-project-1/pull/267)

this PR bring to the project:
- make more optimized Editor code (less calls in OnGUI())
- give additional possibilities to work with Tools for quickly open scenes
How did you implement them?

Minor changes:
- separated code of SO "SceneAccessHolderSO" (SceneAccessHolderSO.cs) on:
-- ReadOnlyPropertyDrawer.cs (It must be in Editor folder - "// The property drawer class should be placed in an editor script, inside a folder called Editor." from Unity Doc)
-- SceneAccessHolderSOReadOnlyAttribute.cs (It must be not in Editor folder, now in folder with corresponding SO)
-- now "SceneAccessHolderSO.cs" contain only clean SO.

Major changes:
- SceneAccessTool.cs
-- Not demand initial creation of SceneAccessHolderSO, if it absent will create automatically
-- Fully sync the window "SceneAccessTool" and SceneAccessHolderSO, The user can simultaneously change the SceneListing values and window display parameters directly in the window itself or in the inspector (by change SO).
- added SceneAccessSOEditor : Editor, which update window if SO changed.
- window display parameters save to SO and will restored, if window was closed
- optimized OnGUI () to reduce the number of method calls
- corrected work with ReorderableList (ToggleEditMode()/OnGui()/OnEnable())  
[![IMAGE ALT TEXT](http://img.youtube.com/vi/itZkOKHsHXQ/0.jpg)](http://www.youtube.com/watch?v=itZkOKHsHXQ "Video 
 which show changes")