### PR TITLE
Add feature to localization : Localize TMP font

### DIFF
--- a/UOP1_Project/Assets/Scripts/Localization/LocalizeComponent_TMProFont.cs
+++ b/UOP1_Project/Assets/Scripts/Localization/LocalizeComponent_TMProFont.cs
@@ -1,0 +1,69 @@
+﻿using TMPro;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.Localization.Components;
+
+namespace UnityEditor.Localization.Plugins.TMPro
+{
+	internal static class LocalizeComponent_TMProFont
+	{
+		[MenuItem("CONTEXT/TextMeshProUGUI/Localize String And Font")]
+		static void LocalizeTMProText(MenuCommand command)
+		{
+			var target = command.context as TextMeshProUGUI;
+			SetupForStringLocalization(target);
+			SetupForFontLocalization(target);
+		}
+
+		public static MonoBehaviour SetupForStringLocalization(TextMeshProUGUI target)
+		{
+			//Avoid adding the component multiple times
+			if (target.GetComponent<LocalizeStringEvent>() != null)
+				return null;
+
+			var comp = Undo.AddComponent(target.gameObject, typeof(LocalizeStringEvent)) as LocalizeStringEvent;
+			var setStringMethod = target.GetType().GetProperty("text").GetSetMethod();
+			var methodDelegate = System.Delegate.CreateDelegate(typeof(UnityAction<string>), target, setStringMethod) as UnityAction<string>;
+			Events.UnityEventTools.AddPersistentListener(comp.OnUpdateString, methodDelegate);
+
+			const int kMatchThreshold = 5;
+			var foundKey = LocalizationEditorSettings.FindSimilarKey(target.text);
+			if (foundKey.collection != null && foundKey.matchDistance < kMatchThreshold)
+			{
+				comp.StringReference.TableEntryReference = foundKey.entry.Id;
+				comp.StringReference.TableReference = foundKey.collection.TableCollectionNameReference;
+			}
+
+			return null;
+		}
+
+		public static MonoBehaviour SetupForFontLocalization(TextMeshProUGUI target)
+		{
+			//Avoid adding the component multiple times
+			if (target.GetComponent<LocalizeTMProFontEvent>() != null)
+				return null;
+
+			var comp = Undo.AddComponent(target.gameObject, typeof(LocalizeTMProFontEvent)) as LocalizeTMProFontEvent;
+			var setFontMethod = target.GetType().GetProperty("font").GetSetMethod();
+			var methodDelegate = System.Delegate.CreateDelegate(typeof(UnityAction<TMP_FontAsset>), target, setFontMethod) as UnityAction<TMP_FontAsset>;
+			Events.UnityEventTools.AddPersistentListener(comp.OnUpdateAsset, methodDelegate);
+
+			//Find font table and set it up automatically
+			var collections = LocalizationEditorSettings.GetAssetTableCollections();
+			foreach (var tableCollection in collections)
+			{
+				if (tableCollection.name == "Fonts")
+				{
+					comp.AssetReference.TableReference = tableCollection.TableCollectionNameReference;
+					foreach (var entry in tableCollection.SharedData.Entries)
+					{
+						if (entry.Key == "font")
+							comp.AssetReference.TableEntryReference = entry.Id;
+					}
+				}
+			}
+
+			return null;
+		}
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Localization/LocalizeComponent_TMProFont.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Localization/LocalizeComponent_TMProFont.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a568b6cd30782a04d891cb0bca6a64a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Localization/LocalizeTMProFontEvent.cs
+++ b/UOP1_Project/Assets/Scripts/Localization/LocalizeTMProFontEvent.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using TMPro;
+using UnityEditor.Localization;
 using UnityEngine.Events;
 
 namespace UnityEngine.Localization.Components
@@ -10,6 +11,29 @@ namespace UnityEngine.Localization.Components
 	[AddComponentMenu("Localization/Asset/Localize TMPro Font Event")]
 	public class LocalizeTMProFontEvent : LocalizedAssetEvent<TMP_FontAsset, LocalizedTMProFont, UnityEventFont>
 	{
+		private void Reset()
+		{
+			//Set up Unity Event automatically
+			var target = GetComponent<TextMeshProUGUI>();
+			var setFontMethod = target.GetType().GetProperty("font").GetSetMethod();
+			var methodDelegate = System.Delegate.CreateDelegate(typeof(UnityAction<TMP_FontAsset>), target, setFontMethod) as UnityAction<TMP_FontAsset>;
+			UnityEditor.Events.UnityEventTools.AddPersistentListener(this.OnUpdateAsset, methodDelegate);
+
+			//Set up font localize asset table automatically
+			var collections = LocalizationEditorSettings.GetAssetTableCollections();
+			foreach (var tableCollection in collections)
+			{
+				if (tableCollection.name == "Fonts")
+				{
+					this.AssetReference.TableReference = tableCollection.TableCollectionNameReference;
+					foreach (var entry in tableCollection.SharedData.Entries)
+					{
+						if (entry.Key == "font")
+							this.AssetReference.TableEntryReference = entry.Id;
+					}
+				}
+			}
+		}
 	}
 
 	[Serializable]

--- a/UOP1_Project/Assets/Scripts/Localization/LocalizeTMProFontEvent.cs
+++ b/UOP1_Project/Assets/Scripts/Localization/LocalizeTMProFontEvent.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using TMPro;
+using UnityEngine.Events;
+
+namespace UnityEngine.Localization.Components
+{
+	/// <summary>
+	/// Component that can be used to Localize a TMP_FontAsset asset.
+	/// </summary>
+	[AddComponentMenu("Localization/Asset/Localize TMPro Font Event")]
+	public class LocalizeTMProFontEvent : LocalizedAssetEvent<TMP_FontAsset, LocalizedTMProFont, UnityEventFont>
+	{
+	}
+
+	[Serializable]
+	public class LocalizedTMProFont : LocalizedAsset<TMP_FontAsset>{ }
+
+	[Serializable]
+	public class UnityEventFont : UnityEvent<TMP_FontAsset> { }
+
+
+}

--- a/UOP1_Project/Assets/Scripts/Localization/LocalizeTMProFontEvent.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Localization/LocalizeTMProFontEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4e8edcf3197e7e409c5a72a3a934676
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION

**Forum:**
[Link to forum](https://forum.unity.com/threads/localization-system.982776/#post-6631024)

**Purpose:**
Localize font base on the game language.
Characters from other languages might be missing if the font doesn't change. (Mainly Asian languages like Chinese, Korean, Japanese..)
![image](https://user-images.githubusercontent.com/54031246/103585103-85be8b80-4eb0-11eb-999d-122f803f256d.png)


**Changes:**
(Add 2 short scripts to implement font localization.)
1. LocalizeTMProFontEvent.cs - Component to localize a TMP_FontAsset
![TMPFont-component](https://user-images.githubusercontent.com/54031246/103583866-80f8d800-4eae-11eb-9589-2cbe6f2d7965.gif)
2. LocalizeComponent_TMProFont.cs - TextmeshProUGUI context menu "Localize String And Font"
![TMPFont](https://user-images.githubusercontent.com/54031246/103583909-979f2f00-4eae-11eb-82cb-b822b4862578.gif)

**Note**
By default, if we create our Font Asset Table with the name "Fonts" and key "font", the component will be automatically set up. Or we can always re-define this name string in the code easily. 
![image](https://user-images.githubusercontent.com/54031246/103584024-d3d28f80-4eae-11eb-9344-0799aba36d52.png)

The naming convention of the classes followed the names and scripts from the localization package.

A small contribute from an unexperienced  Unity user! Thank you and happy new year à tous!
Brett
