### PR TITLE
Corrected plant critter state machine to be aligned with animator

### DIFF
--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Enemies/PlantCritter/Conditions/Timer_PlantFainting.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Enemies/PlantCritter/Conditions/Timer_PlantFainting.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: Timer_PlantFainting
   m_EditorClassIdentifier: 
   cacheResult: 1
-  timerLength: 2.3
+  timerLength: 2.5

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Enemies/PlantCritter/PlantCritter_TransitionTable.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Enemies/PlantCritter/PlantCritter_TransitionTable.asset
@@ -59,16 +59,16 @@ MonoBehaviour:
       Condition: {fileID: 11400000, guid: 5d0cf556c54f5154a9edc595f1958590, type: 2}
       Operator: 0
   - FromState: {fileID: 11400000, guid: 0fe9688a46e58a24d8a88cd363a8e472, type: 2}
+    ToState: {fileID: 11400000, guid: 5b0e38103a74c054cb968153b3227b71, type: 2}
+    Conditions:
+    - ExpectedResult: 0
+      Condition: {fileID: 11400000, guid: 1ff6d66c9ad367543beb3f2455a1d06c, type: 2}
+      Operator: 0
+  - FromState: {fileID: 11400000, guid: 0fe9688a46e58a24d8a88cd363a8e472, type: 2}
     ToState: {fileID: 11400000, guid: 05826b0374eccc245b9b1da390ab7d04, type: 2}
     Conditions:
     - ExpectedResult: 0
       Condition: {fileID: 11400000, guid: 8d78c6cbad5610342b28e8f66a8a9d11, type: 2}
-      Operator: 0
-  - FromState: {fileID: 11400000, guid: ea7a8e48b1a87c241bb721da98d1d812, type: 2}
-    ToState: {fileID: 11400000, guid: 628073f665cfda9468013b5ecbc7e6c3, type: 2}
-    Conditions:
-    - ExpectedResult: 0
-      Condition: {fileID: 11400000, guid: fa8a674126a68004888ee6cef86cb5f5, type: 2}
       Operator: 0
   - FromState: {fileID: 11400000, guid: 628073f665cfda9468013b5ecbc7e6c3, type: 2}
     ToState: {fileID: 11400000, guid: f4a07080dd036db4392317bdcd3c20b4, type: 2}
@@ -103,15 +103,9 @@ MonoBehaviour:
     - ExpectedResult: 0
       Condition: {fileID: 11400000, guid: fa8a674126a68004888ee6cef86cb5f5, type: 2}
       Operator: 0
-  - FromState: {fileID: 11400000, guid: 0fe9688a46e58a24d8a88cd363a8e472, type: 2}
+  - FromState: {fileID: 11400000, guid: 5b0e38103a74c054cb968153b3227b71, type: 2}
     ToState: {fileID: 11400000, guid: 628073f665cfda9468013b5ecbc7e6c3, type: 2}
     Conditions:
     - ExpectedResult: 0
       Condition: {fileID: 11400000, guid: fa8a674126a68004888ee6cef86cb5f5, type: 2}
-      Operator: 0
-  - FromState: {fileID: 11400000, guid: 0fe9688a46e58a24d8a88cd363a8e472, type: 2}
-    ToState: {fileID: 11400000, guid: 5b0e38103a74c054cb968153b3227b71, type: 2}
-    Conditions:
-    - ExpectedResult: 0
-      Condition: {fileID: 11400000, guid: 1ff6d66c9ad367543beb3f2455a1d06c, type: 2}
       Operator: 0


### PR DESCRIPTION
Sometimes when giving the last hit to the plant critter during the plant attack, it happens that the plant is killed without playing the expected BeenHit & Faint animations.

I have just figured out what is going wrong, the attack state in plant critter state machine has transition to dying state, so it happens that the state machine is ahead compare to the animator so some animations are missed. I am removing these transitions (Attack to Dying and Fighting to Dying, and adding BeenHit to Dying).