### PR TITLE
Added Critter SO - Item drop when killed - FR critter names

### DIFF
--- a/UOP1_Project/Assets/AddressableAssetsData/AssetGroups/Localization-Assets-Shared.asset
+++ b/UOP1_Project/Assets/AddressableAssetsData/AssetGroups/Localization-Assets-Shared.asset
@@ -89,6 +89,12 @@ MonoBehaviour:
     m_SerializedLabels: []
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
+  - m_GUID: 753c1cc38ecdc5a4b93227e74555c8d7
+    m_Address: Critters Shared Data
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   m_ReadOnly: 1
   m_Settings: {fileID: 11400000, guid: bffab80dc16c4464b92b2e97b6a1964c, type: 2}
   m_SchemaSet:

--- a/UOP1_Project/Assets/AddressableAssetsData/AssetGroups/Localization-StringTables.asset
+++ b/UOP1_Project/Assets/AddressableAssetsData/AssetGroups/Localization-StringTables.asset
@@ -171,6 +171,20 @@ MonoBehaviour:
     - Locale-fr
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
+  - m_GUID: 8d4813fc8788c4949b7fda8395a3840b
+    m_Address: Critters_en
+    m_ReadOnly: 1
+    m_SerializedLabels:
+    - Locale-en
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
+  - m_GUID: 379b9ca9db427c74bb0cd504865dea33
+    m_Address: Critters_fr
+    m_ReadOnly: 1
+    m_SerializedLabels:
+    - Locale-fr
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   m_ReadOnly: 1
   m_Settings: {fileID: 11400000, guid: bffab80dc16c4464b92b2e97b6a1964c, type: 2}
   m_SchemaSet:

--- a/UOP1_Project/Assets/Localization Files/Asset Tables/Critters.meta
+++ b/UOP1_Project/Assets/Localization Files/Asset Tables/Critters.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 36a0bd934e99ae14b9f42103bb023bfc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Localization Files/Asset Tables/Critters/Critters Shared Data.asset
+++ b/UOP1_Project/Assets/Localization Files/Asset Tables/Critters/Critters Shared Data.asset
@@ -1,0 +1,40 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b11a58205ec3474ca216360e9fa74a8, type: 3}
+  m_Name: Critters Shared Data
+  m_EditorClassIdentifier: 
+  m_TableCollectionName: Critters
+  m_TableCollectionNameGuidString: 753c1cc38ecdc5a4b93227e74555c8d7
+  m_Entries:
+  - m_Id: 8129245184
+    m_Key: PlantCritter
+    m_Metadata:
+      m_Items: []
+  - m_Id: 173183496192
+    m_Key: SlimeCritter
+    m_Metadata:
+      m_Items: []
+  - m_Id: 289701261312
+    m_Key: RockCritter
+    m_Metadata:
+      m_Items: []
+  m_Metadata:
+    m_Items: []
+  m_KeyGenerator:
+    id: 0
+  references:
+    version: 1
+    00000000:
+      type: {class: DistributedUIDGenerator, ns: UnityEngine.Localization.Tables,
+        asm: Unity.Localization}
+      data:
+        m_CustomEpoch: 1610381038103

--- a/UOP1_Project/Assets/Localization Files/Asset Tables/Critters/Critters Shared Data.asset.meta
+++ b/UOP1_Project/Assets/Localization Files/Asset Tables/Critters/Critters Shared Data.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 753c1cc38ecdc5a4b93227e74555c8d7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Localization Files/Asset Tables/Critters/Critters.asset
+++ b/UOP1_Project/Assets/Localization Files/Asset Tables/Critters/Critters.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5be51871efa6c3e4eae1703925c8f5ac, type: 3}
+  m_Name: Critters
+  m_EditorClassIdentifier: 
+  m_SharedTableData: {fileID: 11400000, guid: 753c1cc38ecdc5a4b93227e74555c8d7, type: 2}
+  m_Tables:
+  - {fileID: 11400000, guid: 8d4813fc8788c4949b7fda8395a3840b, type: 2}
+  - {fileID: 11400000, guid: 379b9ca9db427c74bb0cd504865dea33, type: 2}
+  m_Extensions: []
+  m_Group: String Table
+  references:
+    version: 1

--- a/UOP1_Project/Assets/Localization Files/Asset Tables/Critters/Critters.asset.meta
+++ b/UOP1_Project/Assets/Localization Files/Asset Tables/Critters/Critters.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7d376053eca3e6e49bf2409b6335590c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Localization Files/Asset Tables/Critters/Critters_en.asset
+++ b/UOP1_Project/Assets/Localization Files/Asset Tables/Critters/Critters_en.asset
@@ -1,0 +1,34 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9620f8c34305754d8cc9a7e49e852d9, type: 3}
+  m_Name: Critters_en
+  m_EditorClassIdentifier: 
+  m_LocaleId:
+    m_Code: en
+  m_SharedData: {fileID: 11400000, guid: 753c1cc38ecdc5a4b93227e74555c8d7, type: 2}
+  m_Metadata:
+    m_Items: []
+  m_TableData:
+  - m_Id: 8129245184
+    m_Localized: Plant Critter
+    m_Metadata:
+      m_Items: []
+  - m_Id: 173183496192
+    m_Localized: Slime Critter
+    m_Metadata:
+      m_Items: []
+  - m_Id: 289701261312
+    m_Localized: Rock Critter
+    m_Metadata:
+      m_Items: []
+  references:
+    version: 1

--- a/UOP1_Project/Assets/Localization Files/Asset Tables/Critters/Critters_en.asset.meta
+++ b/UOP1_Project/Assets/Localization Files/Asset Tables/Critters/Critters_en.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8d4813fc8788c4949b7fda8395a3840b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Localization Files/Asset Tables/Critters/Critters_fr.asset
+++ b/UOP1_Project/Assets/Localization Files/Asset Tables/Critters/Critters_fr.asset
@@ -1,0 +1,34 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9620f8c34305754d8cc9a7e49e852d9, type: 3}
+  m_Name: Critters_fr
+  m_EditorClassIdentifier: 
+  m_LocaleId:
+    m_Code: fr
+  m_SharedData: {fileID: 11400000, guid: 753c1cc38ecdc5a4b93227e74555c8d7, type: 2}
+  m_Metadata:
+    m_Items: []
+  m_TableData:
+  - m_Id: 8129245184
+    m_Localized: Mauvais Navet
+    m_Metadata:
+      m_Items: []
+  - m_Id: 173183496192
+    m_Localized: "Gluant-\xE0-Pointes"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 289701261312
+    m_Localized: Furieux Rocher
+    m_Metadata:
+      m_Items: []
+  references:
+    version: 1

--- a/UOP1_Project/Assets/Localization Files/Asset Tables/Critters/Critters_fr.asset.meta
+++ b/UOP1_Project/Assets/Localization Files/Asset Tables/Critters/Critters_fr.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 379b9ca9db427c74bb0cd504865dea33
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Prefabs/Characters/PlantCritter.prefab
+++ b/UOP1_Project/Assets/Prefabs/Characters/PlantCritter.prefab
@@ -225,7 +225,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d83d74df43f0a0b42afeaffe5c3e02cc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _fullHealth: 20
+  _critterSO: {fileID: 11400000, guid: 301a61db8a2a4ef408992e723f0b6b53, type: 2}
+  _collectibleItemPrefab: {fileID: 2126586097156616357, guid: 0f60adbc96570cb4e9898a0409956f1d,
+    type: 3}
 --- !u!1001 &8475173613595968630
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/UOP1_Project/Assets/Prefabs/Props/Collectible Item.prefab
+++ b/UOP1_Project/Assets/Prefabs/Props/Collectible Item.prefab
@@ -190,7 +190,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2126586097156616357}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.05, z: -3.708}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2126586096464319708}

--- a/UOP1_Project/Assets/ScriptableObjects/Critters.meta
+++ b/UOP1_Project/Assets/ScriptableObjects/Critters.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 216aa60cd58cdd944828c9ba82ab93fc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/ScriptableObjects/Critters/PlantCritter.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/Critters/PlantCritter.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e005b717defd93a4c81276fd8caab626, type: 3}
+  m_Name: PlantCritter
+  m_EditorClassIdentifier: 
+  _name:
+    m_TableReference:
+      m_TableCollectionName: GUID:753c1cc38ecdc5a4b93227e74555c8d7
+    m_TableEntryReference:
+      m_KeyId: 8129245184
+      m_Key: 
+  _maxHealth: 20
+  _maxNbDropppedItems: 3
+  _dropItems:
+  - _item: {fileID: 11400000, guid: 8aff2c01ad67b48d0a0627754d613415, type: 2}
+    _dropRate: 0.45
+  - _item: {fileID: 11400000, guid: 7a69da03abc7b42a080b2856abaab177, type: 2}
+    _dropRate: 0.45
+  - _item: {fileID: 11400000, guid: 981618c3eb6d24746a53ce7dbe6559a6, type: 2}
+    _dropRate: 0.1

--- a/UOP1_Project/Assets/ScriptableObjects/Critters/PlantCritter.asset.meta
+++ b/UOP1_Project/Assets/ScriptableObjects/Critters/PlantCritter.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 301a61db8a2a4ef408992e723f0b6b53
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Characters/Critter.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/Critter.cs
@@ -4,7 +4,11 @@ using UnityEngine;
 
 public class Critter : MonoBehaviour
 {
-	[SerializeField] private int _fullHealth = 20;
+	[SerializeField]
+	private CritterSO _critterSO;
+
+	[SerializeField]
+	private GameObject _collectibleItemPrefab;
 
 	private int _currentHealth = default;
 
@@ -15,7 +19,7 @@ public class Critter : MonoBehaviour
 
 	private void Awake()
 	{
-		_currentHealth = _fullHealth;
+		_currentHealth = _critterSO.MaxHealth;
 	}
 
 	private void ReceiveAnAttack(int damange)
@@ -37,8 +41,24 @@ public class Critter : MonoBehaviour
 		}
 	}
 
-	public void DestroyCritter()
+	public void CritterIsDead()
 	{
+		// Drop items
+		for (int i = 0; i < _critterSO.GetNbDroppedItems(); i++)
+		{
+			Item item = _critterSO.GetDroppedItem();
+
+			float randPosRight = Random.value * 2 - 1.0f;
+			float randPosForward = Random.value * 2 - 1.0f;
+
+			GameObject collectibleItem = GameObject.Instantiate(_collectibleItemPrefab,
+				gameObject.transform.position + _collectibleItemPrefab.transform.localPosition +
+				2 * (randPosForward * Vector3.forward + randPosRight * Vector3.right),
+				gameObject.transform.localRotation);
+			collectibleItem.GetComponent<CollectibleItem>().CurrentItem = item;
+		}
+
+		// Remove Critter from the game
 		GameObject.Destroy(this.gameObject);
 	}
 }

--- a/UOP1_Project/Assets/Scripts/Characters/DropItem.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/DropItem.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using UnityEngine;
+
+[Serializable]
+public class DropItem
+{
+	[SerializeField]
+	Item _item;
+
+	[SerializeField]
+	float _dropRate;
+
+	public Item Item => _item;
+	public float DropRate => _dropRate;
+}

--- a/UOP1_Project/Assets/Scripts/Characters/DropItem.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Characters/DropItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5a261acff366d9478dd93930316c2f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Characters/ScriptableObjects.meta
+++ b/UOP1_Project/Assets/Scripts/Characters/ScriptableObjects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 884bc7c52eaa3c34bbe59786dc159e99
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Characters/ScriptableObjects/CritterSO.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/ScriptableObjects/CritterSO.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Localization;
+
+[CreateAssetMenu(fileName = "CritterVariant", menuName = "Critter/Critter Variant")]
+public class CritterSO : ScriptableObject
+{
+	[Tooltip("The name of the critter")]
+	[SerializeField]
+	private LocalizedString _name;
+
+	[Tooltip("Initial critter health")]
+	[SerializeField]
+	private int _maxHealth;
+
+
+	[Tooltip("Maximum number of items that can be dropped by the critter when killed.")]
+	[SerializeField]
+	private int _maxNbDropppedItems = 1;
+
+
+	[Tooltip("The list of item that can be dropped by this critter when killed")]
+	[SerializeField]
+	private List<DropItem> _dropItems = new List<DropItem>();
+
+	public LocalizedString Name => _name;
+	public int MaxHealth => _maxHealth;
+	public List<DropItem> DropItems => _dropItems;
+
+	public int GetNbDroppedItems()
+	{
+		return Mathf.CeilToInt(Random.Range(0.0f, _maxNbDropppedItems));
+	}
+
+	public Item GetDroppedItem()
+	{
+		float dropDice = Random.value;
+		float _currentRate = 0.0f;
+		foreach(DropItem dropItem in _dropItems)
+		{
+			_currentRate += dropItem.DropRate;
+			if (_currentRate >= dropDice)
+			{
+				return dropItem.Item;
+			}
+		}
+		return null;
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Characters/ScriptableObjects/CritterSO.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Characters/ScriptableObjects/CritterSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e005b717defd93a4c81276fd8caab626
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/DestroyCritterSO.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/DestroyCritterSO.cs
@@ -24,6 +24,6 @@ public class DestroyCritter : StateAction
 
 	public override void OnStateEnter()
 	{
-		_critter.DestroyCritter();
+		_critter.CritterIsDead();
 	}
 }

--- a/UOP1_Project/Assets/Scripts/Inventory/CollectibleItem.cs
+++ b/UOP1_Project/Assets/Scripts/Inventory/CollectibleItem.cs
@@ -6,6 +6,11 @@ public class CollectibleItem : MonoBehaviour
 	[SerializeField] private Item _currentItem;
 	[SerializeField] private SpriteRenderer[] _itemImages;
 
+	public Item CurrentItem
+	{
+		set => _currentItem = value;
+	}
+
 	private void Start()
 	{
 		SetItem();


### PR DESCRIPTION
Forum thread: [Combat System](https://forum.unity.com/threads/combat-system.1032685/)

The aim of this PR is to add the item dropping to the recently merged combat system. Basically when the plant critter is killed, some collectable items are dropped based on the configuration set up in a new Critter SO attached to the Critter MB script:

This SO will describe a variant of a critter setup (Localized name, Max HP, Max number of items it can drop, the drop rate table associating items to a drop rate (between 0.0 and 1.0)

![image](https://user-images.githubusercontent.com/42570903/104245579-cc8a2380-5464-11eb-9b79-2b414ae716e1.png)

I took this opportunity to add a Critter Name localization table, I tried to find funny critter names in FR ;) 
![image](https://user-images.githubusercontent.com/42570903/104245751-1e32ae00-5465-11eb-8c0a-19c2b6def939.png)

Finally in Critter script, the Critter SO is read / used to instantiate the drop result when the critter is killed:

![image](https://user-images.githubusercontent.com/42570903/104245852-4cb08900-5465-11eb-8e1c-a061d6a3386c.png)

A short demo of this enhancement: [here](https://youtu.be/eAR_zczE3pI)
  