### PR TITLE
Fixes objects moved by ClickToPlaceHelper not being detected in the scene so cannot be saved

### DIFF
--- a/UOP1_Project/Assets/Scripts/EditorTools/ClickToPlaceHelper.cs
+++ b/UOP1_Project/Assets/Scripts/EditorTools/ClickToPlaceHelper.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 [ExecuteInEditMode]
 [AddComponentMenu("UOP1/Tools/Click to Place")]
@@ -34,6 +37,9 @@ public class ClickToPlaceHelper : MonoBehaviour
 	public void EndTargeting()
 	{
 		IsTargeting = false;
+#if UNITY_EDITOR
+		Undo.RecordObject(transform, $"{gameObject.name} moved by ClickToPlaceHelper");
+#endif
 		transform.position = _targetPosition;
 	}
 }


### PR DESCRIPTION
Hi there, new contributor around here 😄 This is my first contribution so I'm keeping it tiny.

This PR fixes #305 

I resolved it by registering the changes made to the transform with `Undo.RecordObject(transform, $"{gameObject.name} moved by ClickToPlaceHelper");`

It can be verified by following the repro steps in issue #305. Here's a video too:

https://user-images.githubusercontent.com/16073309/104380749-64e6dd80-5523-11eb-8960-73042b23ca5e.mp4


