### PR TITLE
SceneAccesTool - added ability to show all scenes in project

### DIFF
--- a/UOP1_Project/Assets/ScriptableObjects/Events/UI/FadeScreenToBlack.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/Events/UI/FadeScreenToBlack.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3177d113f09ae42448cde1e1a5067d4f, type: 3}
+  m_Name: FadeScreenToBlack
+  m_EditorClassIdentifier: 

--- a/UOP1_Project/Assets/ScriptableObjects/Events/UI/FadeScreenToBlack.asset.meta
+++ b/UOP1_Project/Assets/ScriptableObjects/Events/UI/FadeScreenToBlack.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 90e9d9b65bf111e41893bc3e73e655ae
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/CameraManager.cs
+++ b/UOP1_Project/Assets/Scripts/CameraManager.cs
@@ -81,7 +81,7 @@ public class CameraManager : MonoBehaviour
 
 	private void OnCameraMove(Vector2 cameraMovement, bool isDeviceMouse)
 	{
-		Debug.Log(cameraMovement);
+		//Debug.Log(cameraMovement);
 
 		if (_cameraMovementLock)
 			return;

--- a/UOP1_Project/Assets/Scripts/Editor/ScreenFaderToBlackEditor.cs
+++ b/UOP1_Project/Assets/Scripts/Editor/ScreenFaderToBlackEditor.cs
@@ -1,0 +1,24 @@
+﻿using UnityEngine;
+using UnityEditor;
+
+[CustomEditor(typeof(ScreenFaderToBlack))]
+public class ScreenFaderToBlackEditor : Editor
+{
+	ScreenFaderToBlack fader;
+	private void OnEnable()
+	{
+		fader = (ScreenFaderToBlack)target;
+	}
+	public override void OnInspectorGUI()
+	{
+		base.OnInspectorGUI();
+		if (GUILayout.Button("FadeToBlack"))
+		{
+			fader.FadeScreenToBlack(true);
+		}
+		if (GUILayout.Button("FadeFromBlack"))
+		{
+			fader.FadeScreenToBlack(false);
+		}
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Editor/ScreenFaderToBlackEditor.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Editor/ScreenFaderToBlackEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fdd922573c6038449a8192aa735f3cc9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/EditorTools/SceneAccessTool.cs
+++ b/UOP1_Project/Assets/Scripts/EditorTools/SceneAccessTool.cs
@@ -48,6 +48,7 @@ public class SceneAccessTool : EditorWindow, IHasCustomMenu
 						element.FindPropertyRelative("visible"), GUIContent.none);
 				};
 		}
+		PopulateSceneList();
 	}
 	[MenuItem("Tools/SceneAccessTool")]
 	public static void ShowWindow()

--- a/UOP1_Project/Assets/Scripts/SceneManagement/LocationLoader.cs
+++ b/UOP1_Project/Assets/Scripts/SceneManagement/LocationLoader.cs
@@ -24,6 +24,7 @@ public class LocationLoader : MonoBehaviour
 	[Header("Load Event")]
 	//The load event we are listening to
 	[SerializeField] private LoadEventChannelSO _loadEventChannel = default;
+	[SerializeField] private BoolEventChannelSO _fadeScreenToBlack;
 
 	private List<AsyncOperation> _scenesToLoadAsyncOperations = new List<AsyncOperation>();
 	private List<Scene> _scenesToUnload = new List<Scene>();
@@ -40,7 +41,13 @@ public class LocationLoader : MonoBehaviour
 	{
 		_loadEventChannel.OnLoadingRequested -= LoadScenes;
 	}
-
+	private void Awake()
+	{
+		if(_fadeScreenToBlack == null)
+		{
+			Debug.LogError("There is no attatched BoolEventChannelSO for fading screen to black on LocationLoader");
+		}
+	}
 	private void Start()
 	{
 		if (SceneManager.GetActiveScene().name == _initializationScene.sceneName)
@@ -65,6 +72,7 @@ public class LocationLoader : MonoBehaviour
 		AddScenesToUnload();
 		UnloadScenes();
 
+		_fadeScreenToBlack.RaiseEvent(true);
 		if (showLoadingScreen)
 		{
 			_loadingInterface.SetActive(true);
@@ -166,13 +174,13 @@ public class LocationLoader : MonoBehaviour
 			totalProgress = 0;
 			for (int i = 0; i < _scenesToLoadAsyncOperations.Count; ++i)
 			{
-				Debug.Log("Scene " + i + " :" + _scenesToLoadAsyncOperations[i].isDone + " progress = " + _scenesToLoadAsyncOperations[i].progress);
+				//Debug.Log("Scene " + i + " :" + _scenesToLoadAsyncOperations[i].isDone + " progress = " + _scenesToLoadAsyncOperations[i].progress);
 				totalProgress += _scenesToLoadAsyncOperations[i].progress;
 			}
 
 			//The fillAmount is for all scenes, so we divide the progress by the number of scenes to load
 			_loadingProgressBar.fillAmount = totalProgress / _scenesToLoadAsyncOperations.Count;
-			Debug.Log("progress bar " + _loadingProgressBar.fillAmount + " and value = " + totalProgress / _scenesToLoadAsyncOperations.Count);
+			//Debug.Log("progress bar " + _loadingProgressBar.fillAmount + " and value = " + totalProgress / _scenesToLoadAsyncOperations.Count);
 
 			yield return null;
 		}
@@ -183,6 +191,7 @@ public class LocationLoader : MonoBehaviour
 
 		//Hide progress bar when loading is done
 		_loadingInterface.SetActive(false);
+		_fadeScreenToBlack.RaiseEvent(false);
 	}
 
 	private void ExitGame()

--- a/UOP1_Project/Assets/Scripts/UI/ScreenFaderToBlack.cs
+++ b/UOP1_Project/Assets/Scripts/UI/ScreenFaderToBlack.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections;
+using Unity.Mathematics;
+using UnityEngine;
+using UnityEngine.UI;
+
+[RequireComponent(typeof(Image))]
+public class ScreenFaderToBlack : MonoBehaviour
+{
+	public bool isBlack;
+	[SerializeField] private BoolEventChannelSO fadeScreenToBlackEvent;
+	[SerializeField] private float fadeFromBlackTime = 1;
+	[SerializeField] private float fadeToBlackTime = 0;
+	private GameObject blackScreen;
+	private Image blackScreenImage;
+	private bool _toBlack, _waitingToBlack;
+	private bool _fromBlack, _waitingFromBlack;
+	private Color _color;
+	private float _alpha;
+	private void OnEnable()
+	{
+		fadeScreenToBlackEvent.OnEventRaised += FadeScreenToBlack;
+	}
+	private void OnDisable()
+	{
+		fadeScreenToBlackEvent.OnEventRaised -= FadeScreenToBlack;
+	}
+	private void Awake()
+	{
+		blackScreen = transform.gameObject;
+		blackScreenImage = blackScreen.GetComponent<Image>();
+		//On awake make 
+		blackScreenImage.enabled = false;
+		_color = blackScreenImage.color;
+		_color.a = 0;
+		blackScreenImage.color = _color;
+		_alpha = _color.a;
+
+	}
+	public void FadeScreenToBlack(bool toBlack)
+	{
+		if (toBlack)
+		{
+			FadeToBlack();
+		}
+		else
+		{
+			FadeFromBlack();
+		}
+	}
+	private void FadeToBlack()
+	{
+		if (_fromBlack || _waitingFromBlack)
+		{
+			_waitingToBlack = true;
+			return;
+		}
+		blackScreenImage.enabled = true;
+		_toBlack = true;
+		_fromBlack = false;
+	}
+	private void FadeFromBlack()
+	{
+		if (_toBlack || _waitingToBlack)
+		{
+			_waitingFromBlack = true;
+			return;
+		}
+		blackScreenImage.enabled = true;
+		_toBlack = false;
+		_fromBlack = true;
+	}
+
+	private void SetColor()
+	{
+		_alpha = math.clamp(_alpha, 0, 1);
+		_color.a = _alpha;
+		blackScreenImage.color = _color;
+	}
+	private void Update()
+	{
+		//(_waitingToBlack && !_fromBlack) means that do only if ToBlack is on queue and fromBlack completed
+		if (_toBlack || (_waitingToBlack && !_fromBlack))
+		{
+			if (_alpha < 1)
+			{
+				_alpha += Time.deltaTime * 1 / fadeToBlackTime;
+				SetColor();
+			}
+			else
+			{
+				isBlack = true;
+				_toBlack = false;
+				_waitingToBlack = false;
+			
+			}
+		}
+		//(_waitingFromBlack && !_toBlack) means that do only if fromBlack is on queue and toBlack completed
+		else if (_fromBlack || (_waitingFromBlack && !_toBlack))
+		{
+			if (_alpha > 0)
+			{
+				_alpha -= Time.deltaTime * 1 / fadeFromBlackTime;
+				SetColor();
+			}
+			else
+			{
+				isBlack = false;
+				_fromBlack = false;
+				_waitingFromBlack = false;
+				
+				//if disable blackScreen when waitingToBlack - alpha will go up but image will be not visible
+				if (!_waitingToBlack)
+					blackScreenImage.enabled = false;
+			}
+
+		}
+	}
+}

--- a/UOP1_Project/Assets/Scripts/UI/ScreenFaderToBlack.cs.meta
+++ b/UOP1_Project/Assets/Scripts/UI/ScreenFaderToBlack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2367cf163d0a7e74d9dd7914c668b183
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
New Toggle - ToggleShowAllScenes
Added directory search algorithm
Added scroll

There is no forum linked to this PR. 
This small change allows to navigate through scenes that are not in the build setting. I think it will be helpful for someone.

How the algorithm works:
(DirectoryInfo contains FileInfo's. FileInfo's contains names and path of files in certain directory)
Get DirectoryInfo of "Assets/Scenes".
Add this DirectoryInfo to the DirInfos list.
While we not reached end of DirInfos list:
     current Directory is one from DirInfos list.
     search current Directory for subDirectories and add them to the DirInfos list.
     search current Directory for scene files and add them to the AllScenes list.
