### PR TITLE
State Machine Improvements

### DIFF
--- a/UOP1_Project/Assets/Scripts/Input/GameInput.cs
+++ b/UOP1_Project/Assets/Scripts/Input/GameInput.cs
@@ -8,10 +8,10 @@ using UnityEngine.InputSystem.Utilities;
 
 public class @GameInput : IInputActionCollection, IDisposable
 {
-    public InputActionAsset asset { get; }
-    public @GameInput()
-    {
-        asset = InputActionAsset.FromJson(@"{
+	public InputActionAsset asset { get; }
+	public @GameInput()
+	{
+		asset = InputActionAsset.FromJson(@"{
     ""name"": ""GameInput"",
     ""maps"": [
         {
@@ -1110,288 +1110,289 @@ public class @GameInput : IInputActionCollection, IDisposable
         }
     ]
 }");
-        // Gameplay
-        m_Gameplay = asset.FindActionMap("Gameplay", throwIfNotFound: true);
-        m_Gameplay_Move = m_Gameplay.FindAction("Move", throwIfNotFound: true);
-        m_Gameplay_Jump = m_Gameplay.FindAction("Jump", throwIfNotFound: true);
-        m_Gameplay_Attack = m_Gameplay.FindAction("Attack", throwIfNotFound: true);
-        m_Gameplay_Interact = m_Gameplay.FindAction("Interact", throwIfNotFound: true);
-        m_Gameplay_Pause = m_Gameplay.FindAction("Pause", throwIfNotFound: true);
-        m_Gameplay_ExtraAction = m_Gameplay.FindAction("ExtraAction", throwIfNotFound: true);
-        m_Gameplay_RotateCamera = m_Gameplay.FindAction("RotateCamera", throwIfNotFound: true);
-        m_Gameplay_MouseControlCamera = m_Gameplay.FindAction("MouseControlCamera", throwIfNotFound: true);
-        m_Gameplay_Run = m_Gameplay.FindAction("Run", throwIfNotFound: true);
-        // Menus
-        m_Menus = asset.FindActionMap("Menus", throwIfNotFound: true);
-        m_Menus_MoveSelection = m_Menus.FindAction("MoveSelection", throwIfNotFound: true);
-        m_Menus_Confirm = m_Menus.FindAction("Confirm", throwIfNotFound: true);
-        m_Menus_Cancel = m_Menus.FindAction("Cancel", throwIfNotFound: true);
-        // Dialogues
-        m_Dialogues = asset.FindActionMap("Dialogues", throwIfNotFound: true);
-        m_Dialogues_MoveSelection = m_Dialogues.FindAction("MoveSelection", throwIfNotFound: true);
-        m_Dialogues_AdvanceDialogue = m_Dialogues.FindAction("AdvanceDialogue", throwIfNotFound: true);
-    }
+		// Gameplay
+		m_Gameplay = asset.FindActionMap("Gameplay", throwIfNotFound: true);
+		m_Gameplay_Move = m_Gameplay.FindAction("Move", throwIfNotFound: true);
+		m_Gameplay_Jump = m_Gameplay.FindAction("Jump", throwIfNotFound: true);
+		m_Gameplay_Attack = m_Gameplay.FindAction("Attack", throwIfNotFound: true);
+		m_Gameplay_Interact = m_Gameplay.FindAction("Interact", throwIfNotFound: true);
+		m_Gameplay_Pause = m_Gameplay.FindAction("Pause", throwIfNotFound: true);
+		m_Gameplay_ExtraAction = m_Gameplay.FindAction("ExtraAction", throwIfNotFound: true);
+		m_Gameplay_RotateCamera = m_Gameplay.FindAction("RotateCamera", throwIfNotFound: true);
+		m_Gameplay_MouseControlCamera = m_Gameplay.FindAction("MouseControlCamera", throwIfNotFound: true);
+		m_Gameplay_Run = m_Gameplay.FindAction("Run", throwIfNotFound: true);
+		// Menus
+		m_Menus = asset.FindActionMap("Menus", throwIfNotFound: true);
+		m_Menus_MoveSelection = m_Menus.FindAction("MoveSelection", throwIfNotFound: true);
+		m_Menus_Confirm = m_Menus.FindAction("Confirm", throwIfNotFound: true);
+		m_Menus_Cancel = m_Menus.FindAction("Cancel", throwIfNotFound: true);
+		// Dialogues
+		m_Dialogues = asset.FindActionMap("Dialogues", throwIfNotFound: true);
+		m_Dialogues_MoveSelection = m_Dialogues.FindAction("MoveSelection", throwIfNotFound: true);
+		m_Dialogues_AdvanceDialogue = m_Dialogues.FindAction("AdvanceDialogue", throwIfNotFound: true);
+	}
 
-    public void Dispose()
-    {
-        UnityEngine.Object.Destroy(asset);
-    }
+	public void Dispose()
+	{
+		UnityEngine.Object.Destroy(asset);
+	}
 
-    public InputBinding? bindingMask
-    {
-        get => asset.bindingMask;
-        set => asset.bindingMask = value;
-    }
+	public InputBinding? bindingMask
+	{
+		get => asset.bindingMask;
+		set => asset.bindingMask = value;
+	}
 
-    public ReadOnlyArray<InputDevice>? devices
-    {
-        get => asset.devices;
-        set => asset.devices = value;
-    }
+	public ReadOnlyArray<InputDevice>? devices
+	{
+		get => asset.devices;
+		set => asset.devices = value;
+	}
 
-    public ReadOnlyArray<InputControlScheme> controlSchemes => asset.controlSchemes;
+	public ReadOnlyArray<InputControlScheme> controlSchemes => asset.controlSchemes;
 
-    public bool Contains(InputAction action)
-    {
-        return asset.Contains(action);
-    }
+	public bool Contains(InputAction action)
+	{
+		return asset.Contains(action);
+	}
 
-    public IEnumerator<InputAction> GetEnumerator()
-    {
-        return asset.GetEnumerator();
-    }
+	public IEnumerator<InputAction> GetEnumerator()
+	{
+		return asset.GetEnumerator();
+	}
 
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
+	IEnumerator IEnumerable.GetEnumerator()
+	{
+		return GetEnumerator();
+	}
 
-    public void Enable()
-    {
-        asset.Enable();
-    }
+	public void Enable()
+	{
+		asset.Enable();
+	}
 
-    public void Disable()
-    {
-        asset.Disable();
-    }
+	public void Disable()
+	{
+		asset.Disable();
+	}
 
-    // Gameplay
-    private readonly InputActionMap m_Gameplay;
-    private IGameplayActions m_GameplayActionsCallbackInterface;
-    private readonly InputAction m_Gameplay_Move;
-    private readonly InputAction m_Gameplay_Jump;
-    private readonly InputAction m_Gameplay_Attack;
-    private readonly InputAction m_Gameplay_Interact;
-    private readonly InputAction m_Gameplay_Pause;
-    private readonly InputAction m_Gameplay_ExtraAction;
-    private readonly InputAction m_Gameplay_RotateCamera;
-    private readonly InputAction m_Gameplay_MouseControlCamera;
-    private readonly InputAction m_Gameplay_Run;
-    public struct GameplayActions
-    {
-        private @GameInput m_Wrapper;
-        public GameplayActions(@GameInput wrapper) { m_Wrapper = wrapper; }
-        public InputAction @Move => m_Wrapper.m_Gameplay_Move;
-        public InputAction @Jump => m_Wrapper.m_Gameplay_Jump;
-        public InputAction @Attack => m_Wrapper.m_Gameplay_Attack;
-        public InputAction @Interact => m_Wrapper.m_Gameplay_Interact;
-        public InputAction @Pause => m_Wrapper.m_Gameplay_Pause;
-        public InputAction @ExtraAction => m_Wrapper.m_Gameplay_ExtraAction;
-        public InputAction @RotateCamera => m_Wrapper.m_Gameplay_RotateCamera;
-        public InputAction @MouseControlCamera => m_Wrapper.m_Gameplay_MouseControlCamera;
-        public InputAction @Run => m_Wrapper.m_Gameplay_Run;
-        public InputActionMap Get() { return m_Wrapper.m_Gameplay; }
-        public void Enable() { Get().Enable(); }
-        public void Disable() { Get().Disable(); }
-        public bool enabled => Get().enabled;
-        public static implicit operator InputActionMap(GameplayActions set) { return set.Get(); }
-        public void SetCallbacks(IGameplayActions instance)
-        {
-            if (m_Wrapper.m_GameplayActionsCallbackInterface != null)
-            {
-                @Move.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
-                @Move.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
-                @Move.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
-                @Jump.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnJump;
-                @Jump.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnJump;
-                @Jump.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnJump;
-                @Attack.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnAttack;
-                @Attack.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnAttack;
-                @Attack.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnAttack;
-                @Interact.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnInteract;
-                @Interact.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnInteract;
-                @Interact.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnInteract;
-                @Pause.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnPause;
-                @Pause.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnPause;
-                @Pause.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnPause;
-                @ExtraAction.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnExtraAction;
-                @ExtraAction.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnExtraAction;
-                @ExtraAction.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnExtraAction;
-                @RotateCamera.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRotateCamera;
-                @RotateCamera.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRotateCamera;
-                @RotateCamera.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRotateCamera;
-                @MouseControlCamera.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMouseControlCamera;
-                @MouseControlCamera.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMouseControlCamera;
-                @MouseControlCamera.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMouseControlCamera;
-                @Run.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRun;
-                @Run.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRun;
-                @Run.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRun;
-            }
-            m_Wrapper.m_GameplayActionsCallbackInterface = instance;
-            if (instance != null)
-            {
-                @Move.started += instance.OnMove;
-                @Move.performed += instance.OnMove;
-                @Move.canceled += instance.OnMove;
-                @Jump.started += instance.OnJump;
-                @Jump.performed += instance.OnJump;
-                @Jump.canceled += instance.OnJump;
-                @Attack.started += instance.OnAttack;
-                @Attack.performed += instance.OnAttack;
-                @Attack.canceled += instance.OnAttack;
-                @Interact.started += instance.OnInteract;
-                @Interact.performed += instance.OnInteract;
-                @Interact.canceled += instance.OnInteract;
-                @Pause.started += instance.OnPause;
-                @Pause.performed += instance.OnPause;
-                @Pause.canceled += instance.OnPause;
-                @ExtraAction.started += instance.OnExtraAction;
-                @ExtraAction.performed += instance.OnExtraAction;
-                @ExtraAction.canceled += instance.OnExtraAction;
-                @RotateCamera.started += instance.OnRotateCamera;
-                @RotateCamera.performed += instance.OnRotateCamera;
-                @RotateCamera.canceled += instance.OnRotateCamera;
-                @MouseControlCamera.started += instance.OnMouseControlCamera;
-                @MouseControlCamera.performed += instance.OnMouseControlCamera;
-                @MouseControlCamera.canceled += instance.OnMouseControlCamera;
-                @Run.started += instance.OnRun;
-                @Run.performed += instance.OnRun;
-                @Run.canceled += instance.OnRun;
-            }
-        }
-    }
-    public GameplayActions @Gameplay => new GameplayActions(this);
+	// Gameplay
+	private readonly InputActionMap m_Gameplay;
+	private IGameplayActions m_GameplayActionsCallbackInterface;
+	private readonly InputAction m_Gameplay_Move;
+	private readonly InputAction m_Gameplay_Jump;
+	private readonly InputAction m_Gameplay_Attack;
+	private readonly InputAction m_Gameplay_Interact;
+	private readonly InputAction m_Gameplay_Pause;
+	private readonly InputAction m_Gameplay_ExtraAction;
+	private readonly InputAction m_Gameplay_RotateCamera;
+	private readonly InputAction m_Gameplay_MouseControlCamera;
+	private readonly InputAction m_Gameplay_Run;
+	public struct GameplayActions
+	{
+		private @GameInput m_Wrapper;
+		public GameplayActions(@GameInput wrapper) { m_Wrapper = wrapper; }
+		public InputAction @Move => m_Wrapper.m_Gameplay_Move;
+		public InputAction @Jump => m_Wrapper.m_Gameplay_Jump;
+		public InputAction @Attack => m_Wrapper.m_Gameplay_Attack;
+		public InputAction @Interact => m_Wrapper.m_Gameplay_Interact;
+		public InputAction @Pause => m_Wrapper.m_Gameplay_Pause;
+		public InputAction @ExtraAction => m_Wrapper.m_Gameplay_ExtraAction;
+		public InputAction @RotateCamera => m_Wrapper.m_Gameplay_RotateCamera;
+		public InputAction @MouseControlCamera => m_Wrapper.m_Gameplay_MouseControlCamera;
+		public InputAction @Run => m_Wrapper.m_Gameplay_Run;
+		public InputActionMap Get() { return m_Wrapper.m_Gameplay; }
+		public void Enable() { Get().Enable(); }
+		public void Disable() { Get().Disable(); }
+		public bool enabled => Get().enabled;
+		public static implicit operator InputActionMap(GameplayActions set) { return set.Get(); }
+		public void SetCallbacks(IGameplayActions instance)
+		{
+			if (m_Wrapper.m_GameplayActionsCallbackInterface != null)
+			{
+				@Move.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
+				@Move.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
+				@Move.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
+				@Jump.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnJump;
+				@Jump.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnJump;
+				@Jump.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnJump;
+				@Attack.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnAttack;
+				@Attack.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnAttack;
+				@Attack.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnAttack;
+				@Interact.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnInteract;
+				@Interact.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnInteract;
+				@Interact.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnInteract;
+				@Pause.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnPause;
+				@Pause.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnPause;
+				@Pause.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnPause;
+				@ExtraAction.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnExtraAction;
+				@ExtraAction.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnExtraAction;
+				@ExtraAction.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnExtraAction;
+				@RotateCamera.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRotateCamera;
+				@RotateCamera.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRotateCamera;
+				@RotateCamera.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRotateCamera;
+				@MouseControlCamera.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMouseControlCamera;
+				@MouseControlCamera.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMouseControlCamera;
+				@MouseControlCamera.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMouseControlCamera;
+				@Run.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRun;
+				@Run.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRun;
+				@Run.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnRun;
+			}
+			m_Wrapper.m_GameplayActionsCallbackInterface = instance;
+			if (instance != null)
+			{
+				@Move.started += instance.OnMove;
+				@Move.performed += instance.OnMove;
+				@Move.canceled += instance.OnMove;
+				@Jump.started += instance.OnJump;
+				@Jump.performed += instance.OnJump;
+				@Jump.canceled += instance.OnJump;
+				@Attack.started += instance.OnAttack;
+				@Attack.performed += instance.OnAttack;
+				@Attack.canceled += instance.OnAttack;
+				@Interact.started += instance.OnInteract;
+				@Interact.performed += instance.OnInteract;
+				@Interact.canceled += instance.OnInteract;
+				@Pause.started += instance.OnPause;
+				@Pause.performed += instance.OnPause;
+				@Pause.canceled += instance.OnPause;
+				@ExtraAction.started += instance.OnExtraAction;
+				@ExtraAction.performed += instance.OnExtraAction;
+				@ExtraAction.canceled += instance.OnExtraAction;
+				@RotateCamera.started += instance.OnRotateCamera;
+				@RotateCamera.performed += instance.OnRotateCamera;
+				@RotateCamera.canceled += instance.OnRotateCamera;
+				@MouseControlCamera.started += instance.OnMouseControlCamera;
+				@MouseControlCamera.performed += instance.OnMouseControlCamera;
+				@MouseControlCamera.canceled += instance.OnMouseControlCamera;
+				@Run.started += instance.OnRun;
+				@Run.performed += instance.OnRun;
+				@Run.canceled += instance.OnRun;
+			}
+		}
+	}
+	public GameplayActions @Gameplay => new GameplayActions(this);
 
-    // Menus
-    private readonly InputActionMap m_Menus;
-    private IMenusActions m_MenusActionsCallbackInterface;
-    private readonly InputAction m_Menus_MoveSelection;
-    private readonly InputAction m_Menus_Confirm;
-    private readonly InputAction m_Menus_Cancel;
-    public struct MenusActions
-    {
-        private @GameInput m_Wrapper;
-        public MenusActions(@GameInput wrapper) { m_Wrapper = wrapper; }
-        public InputAction @MoveSelection => m_Wrapper.m_Menus_MoveSelection;
-        public InputAction @Confirm => m_Wrapper.m_Menus_Confirm;
-        public InputAction @Cancel => m_Wrapper.m_Menus_Cancel;
-        public InputActionMap Get() { return m_Wrapper.m_Menus; }
-        public void Enable() { Get().Enable(); }
-        public void Disable() { Get().Disable(); }
-        public bool enabled => Get().enabled;
-        public static implicit operator InputActionMap(MenusActions set) { return set.Get(); }
-        public void SetCallbacks(IMenusActions instance)
-        {
-            if (m_Wrapper.m_MenusActionsCallbackInterface != null)
-            {
-                @MoveSelection.started -= m_Wrapper.m_MenusActionsCallbackInterface.OnMoveSelection;
-                @MoveSelection.performed -= m_Wrapper.m_MenusActionsCallbackInterface.OnMoveSelection;
-                @MoveSelection.canceled -= m_Wrapper.m_MenusActionsCallbackInterface.OnMoveSelection;
-                @Confirm.started -= m_Wrapper.m_MenusActionsCallbackInterface.OnConfirm;
-                @Confirm.performed -= m_Wrapper.m_MenusActionsCallbackInterface.OnConfirm;
-                @Confirm.canceled -= m_Wrapper.m_MenusActionsCallbackInterface.OnConfirm;
-                @Cancel.started -= m_Wrapper.m_MenusActionsCallbackInterface.OnCancel;
-                @Cancel.performed -= m_Wrapper.m_MenusActionsCallbackInterface.OnCancel;
-                @Cancel.canceled -= m_Wrapper.m_MenusActionsCallbackInterface.OnCancel;
-            }
-            m_Wrapper.m_MenusActionsCallbackInterface = instance;
-            if (instance != null)
-            {
-                @MoveSelection.started += instance.OnMoveSelection;
-                @MoveSelection.performed += instance.OnMoveSelection;
-                @MoveSelection.canceled += instance.OnMoveSelection;
-                @Confirm.started += instance.OnConfirm;
-                @Confirm.performed += instance.OnConfirm;
-                @Confirm.canceled += instance.OnConfirm;
-                @Cancel.started += instance.OnCancel;
-                @Cancel.performed += instance.OnCancel;
-                @Cancel.canceled += instance.OnCancel;
-            }
-        }
-    }
-    public MenusActions @Menus => new MenusActions(this);
+	// Menus
+	private readonly InputActionMap m_Menus;
+	private IMenusActions m_MenusActionsCallbackInterface;
+	private readonly InputAction m_Menus_MoveSelection;
+	private readonly InputAction m_Menus_Confirm;
+	private readonly InputAction m_Menus_Cancel;
+	public struct MenusActions
+	{
+		private @GameInput m_Wrapper;
+		public MenusActions(@GameInput wrapper) { m_Wrapper = wrapper; }
+		public InputAction @MoveSelection => m_Wrapper.m_Menus_MoveSelection;
+		public InputAction @Confirm => m_Wrapper.m_Menus_Confirm;
+		public InputAction @Cancel => m_Wrapper.m_Menus_Cancel;
+		public InputActionMap Get() { return m_Wrapper.m_Menus; }
+		public void Enable() { Get().Enable(); }
+		public void Disable() { Get().Disable(); }
+		public bool enabled => Get().enabled;
+		public static implicit operator InputActionMap(MenusActions set) { return set.Get(); }
+		public void SetCallbacks(IMenusActions instance)
+		{
+			if (m_Wrapper.m_MenusActionsCallbackInterface != null)
+			{
+				@MoveSelection.started -= m_Wrapper.m_MenusActionsCallbackInterface.OnMoveSelection;
+				@MoveSelection.performed -= m_Wrapper.m_MenusActionsCallbackInterface.OnMoveSelection;
+				@MoveSelection.canceled -= m_Wrapper.m_MenusActionsCallbackInterface.OnMoveSelection;
+				@Confirm.started -= m_Wrapper.m_MenusActionsCallbackInterface.OnConfirm;
+				@Confirm.performed -= m_Wrapper.m_MenusActionsCallbackInterface.OnConfirm;
+				@Confirm.canceled -= m_Wrapper.m_MenusActionsCallbackInterface.OnConfirm;
+				@Cancel.started -= m_Wrapper.m_MenusActionsCallbackInterface.OnCancel;
+				@Cancel.performed -= m_Wrapper.m_MenusActionsCallbackInterface.OnCancel;
+				@Cancel.canceled -= m_Wrapper.m_MenusActionsCallbackInterface.OnCancel;
+			}
+			m_Wrapper.m_MenusActionsCallbackInterface = instance;
+			if (instance != null)
+			{
+				@MoveSelection.started += instance.OnMoveSelection;
+				@MoveSelection.performed += instance.OnMoveSelection;
+				@MoveSelection.canceled += instance.OnMoveSelection;
+				@Confirm.started += instance.OnConfirm;
+				@Confirm.performed += instance.OnConfirm;
+				@Confirm.canceled += instance.OnConfirm;
+				@Cancel.started += instance.OnCancel;
+				@Cancel.performed += instance.OnCancel;
+				@Cancel.canceled += instance.OnCancel;
+			}
+		}
+	}
+	public MenusActions @Menus => new MenusActions(this);
 
-    // Dialogues
-    private readonly InputActionMap m_Dialogues;
-    private IDialoguesActions m_DialoguesActionsCallbackInterface;
-    private readonly InputAction m_Dialogues_MoveSelection;
-    private readonly InputAction m_Dialogues_AdvanceDialogue;
-    public struct DialoguesActions
-    {
-        private @GameInput m_Wrapper;
-        public DialoguesActions(@GameInput wrapper) { m_Wrapper = wrapper; }
-        public InputAction @MoveSelection => m_Wrapper.m_Dialogues_MoveSelection;
-        public InputAction @AdvanceDialogue => m_Wrapper.m_Dialogues_AdvanceDialogue;
-        public InputActionMap Get() { return m_Wrapper.m_Dialogues; }
-        public void Enable() { Get().Enable(); }
-        public void Disable() { Get().Disable(); }
-        public bool enabled => Get().enabled;
-        public static implicit operator InputActionMap(DialoguesActions set) { return set.Get(); }
-        public void SetCallbacks(IDialoguesActions instance)
-        {
-            if (m_Wrapper.m_DialoguesActionsCallbackInterface != null)
-            {
-                @MoveSelection.started -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnMoveSelection;
-                @MoveSelection.performed -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnMoveSelection;
-                @MoveSelection.canceled -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnMoveSelection;
-                @AdvanceDialogue.started -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnAdvanceDialogue;
-                @AdvanceDialogue.performed -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnAdvanceDialogue;
-                @AdvanceDialogue.canceled -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnAdvanceDialogue;
-            }
-            m_Wrapper.m_DialoguesActionsCallbackInterface = instance;
-            if (instance != null)
-            {
-                @MoveSelection.started += instance.OnMoveSelection;
-                @MoveSelection.performed += instance.OnMoveSelection;
-                @MoveSelection.canceled += instance.OnMoveSelection;
-                @AdvanceDialogue.started += instance.OnAdvanceDialogue;
-                @AdvanceDialogue.performed += instance.OnAdvanceDialogue;
-                @AdvanceDialogue.canceled += instance.OnAdvanceDialogue;
-            }
-        }
-    }
-    public DialoguesActions @Dialogues => new DialoguesActions(this);
-    private int m_KeyboardOrGamepadSchemeIndex = -1;
-    public InputControlScheme KeyboardOrGamepadScheme
-    {
-        get
-        {
-            if (m_KeyboardOrGamepadSchemeIndex == -1) m_KeyboardOrGamepadSchemeIndex = asset.FindControlSchemeIndex("KeyboardOrGamepad");
-            return asset.controlSchemes[m_KeyboardOrGamepadSchemeIndex];
-        }
-    }
-    public interface IGameplayActions
-    {
-        void OnMove(InputAction.CallbackContext context);
-        void OnJump(InputAction.CallbackContext context);
-        void OnAttack(InputAction.CallbackContext context);
-        void OnInteract(InputAction.CallbackContext context);
-        void OnPause(InputAction.CallbackContext context);
-        void OnExtraAction(InputAction.CallbackContext context);
-        void OnRotateCamera(InputAction.CallbackContext context);
-        void OnMouseControlCamera(InputAction.CallbackContext context);
-        void OnRun(InputAction.CallbackContext context);
-    }
-    public interface IMenusActions
-    {
-        void OnMoveSelection(InputAction.CallbackContext context);
-        void OnConfirm(InputAction.CallbackContext context);
-        void OnCancel(InputAction.CallbackContext context);
-    }
-    public interface IDialoguesActions
-    {
-        void OnMoveSelection(InputAction.CallbackContext context);
-        void OnAdvanceDialogue(InputAction.CallbackContext context);
-    }
+	// Dialogues
+	private readonly InputActionMap m_Dialogues;
+	private IDialoguesActions m_DialoguesActionsCallbackInterface;
+	private readonly InputAction m_Dialogues_MoveSelection;
+	private readonly InputAction m_Dialogues_AdvanceDialogue;
+	public struct DialoguesActions
+	{
+		private @GameInput m_Wrapper;
+		public DialoguesActions(@GameInput wrapper) { m_Wrapper = wrapper; }
+		public InputAction @MoveSelection => m_Wrapper.m_Dialogues_MoveSelection;
+		public InputAction @AdvanceDialogue => m_Wrapper.m_Dialogues_AdvanceDialogue;
+		public InputActionMap Get() { return m_Wrapper.m_Dialogues; }
+		public void Enable() { Get().Enable(); }
+		public void Disable() { Get().Disable(); }
+		public bool enabled => Get().enabled;
+		public static implicit operator InputActionMap(DialoguesActions set) { return set.Get(); }
+		public void SetCallbacks(IDialoguesActions instance)
+		{
+			if (m_Wrapper.m_DialoguesActionsCallbackInterface != null)
+			{
+				@MoveSelection.started -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnMoveSelection;
+				@MoveSelection.performed -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnMoveSelection;
+				@MoveSelection.canceled -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnMoveSelection;
+				@AdvanceDialogue.started -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnAdvanceDialogue;
+				@AdvanceDialogue.performed -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnAdvanceDialogue;
+				@AdvanceDialogue.canceled -= m_Wrapper.m_DialoguesActionsCallbackInterface.OnAdvanceDialogue;
+			}
+			m_Wrapper.m_DialoguesActionsCallbackInterface = instance;
+			if (instance != null)
+			{
+				@MoveSelection.started += instance.OnMoveSelection;
+				@MoveSelection.performed += instance.OnMoveSelection;
+				@MoveSelection.canceled += instance.OnMoveSelection;
+				@AdvanceDialogue.started += instance.OnAdvanceDialogue;
+				@AdvanceDialogue.performed += instance.OnAdvanceDialogue;
+				@AdvanceDialogue.canceled += instance.OnAdvanceDialogue;
+			}
+		}
+	}
+	public DialoguesActions @Dialogues => new DialoguesActions(this);
+	private int m_KeyboardOrGamepadSchemeIndex = -1;
+	public InputControlScheme KeyboardOrGamepadScheme
+	{
+		get
+		{
+			if (m_KeyboardOrGamepadSchemeIndex == -1)
+				m_KeyboardOrGamepadSchemeIndex = asset.FindControlSchemeIndex("KeyboardOrGamepad");
+			return asset.controlSchemes[m_KeyboardOrGamepadSchemeIndex];
+		}
+	}
+	public interface IGameplayActions
+	{
+		void OnMove(InputAction.CallbackContext context);
+		void OnJump(InputAction.CallbackContext context);
+		void OnAttack(InputAction.CallbackContext context);
+		void OnInteract(InputAction.CallbackContext context);
+		void OnPause(InputAction.CallbackContext context);
+		void OnExtraAction(InputAction.CallbackContext context);
+		void OnRotateCamera(InputAction.CallbackContext context);
+		void OnMouseControlCamera(InputAction.CallbackContext context);
+		void OnRun(InputAction.CallbackContext context);
+	}
+	public interface IMenusActions
+	{
+		void OnMoveSelection(InputAction.CallbackContext context);
+		void OnConfirm(InputAction.CallbackContext context);
+		void OnCancel(InputAction.CallbackContext context);
+	}
+	public interface IDialoguesActions
+	{
+		void OnMoveSelection(InputAction.CallbackContext context);
+		void OnAdvanceDialogue(InputAction.CallbackContext context);
+	}
 }

--- a/UOP1_Project/Assets/Scripts/StateMachine/Core/StateAction.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Core/StateAction.cs
@@ -8,6 +8,10 @@ namespace UOP1.StateMachine
 	public abstract class StateAction : IStateComponent
 	{
 		internal StateActionSO _originSO;
+
+		/// <summary>
+		/// Use this property to access shared data from the <see cref="StateActionSO"/> that corresponds to this <see cref="StateAction"/>
+		/// </summary>
 		protected StateActionSO OriginSO => _originSO;
 
 		/// <summary>

--- a/UOP1_Project/Assets/Scripts/StateMachine/Core/StateCondition.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Core/StateCondition.cs
@@ -10,6 +10,10 @@ namespace UOP1.StateMachine
 		private bool _isCached = false;
 		private bool _cachedStatement = default;
 		internal StateConditionSO _originSO;
+
+		/// <summary>
+		/// Use this property to access shared data from the <see cref="StateConditionSO"/> that corresponds to this <see cref="Condition"/>
+		/// </summary>
 		protected StateConditionSO OriginSO => _originSO;
 
 		/// <summary>

--- a/UOP1_Project/Assets/Scripts/StateMachine/Core/StateMachine.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Core/StateMachine.cs
@@ -21,10 +21,14 @@ namespace UOP1.StateMachine
 		private void Awake()
 		{
 			_currentState = _transitionTableSO.GetInitialState(this);
-			_currentState.OnStateEnter();
 #if UNITY_EDITOR
 			_debugger.Awake(this);
 #endif
+		}
+
+		private void Start()
+		{
+			_currentState.OnStateEnter();
 		}
 
 		public new bool TryGetComponent<T>(out T component) where T : Component

--- a/UOP1_Project/Assets/Scripts/StateMachine/Editor/Templates/StateAction.txt
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Editor/Templates/StateAction.txt
@@ -10,19 +10,21 @@ public class #SCRIPTNAME# : StateActionSO
 
 public class #RUNTIMENAME# : StateAction
 {
+	protected new #SCRIPTNAME# OriginSO => (#SCRIPTNAME#)base.OriginSO;
+
 	public override void Awake(StateMachine stateMachine)
 	{
 	}
-		
+	
 	public override void OnUpdate()
 	{
 	}
 	
-	// public override void OnStateEnter()
-	// {
-	// }
+	public override void OnStateEnter()
+	{
+	}
 	
-	// public override void OnStateExit()
-	// {
-	// }
+	public override void OnStateExit()
+	{
+	}
 }

--- a/UOP1_Project/Assets/Scripts/StateMachine/Editor/Templates/StateCondition.txt
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Editor/Templates/StateCondition.txt
@@ -10,20 +10,22 @@ public class #SCRIPTNAME# : StateConditionSO
 
 public class #RUNTIMENAME# : Condition
 {
+	protected new #SCRIPTNAME# OriginSO => (#SCRIPTNAME#)base.OriginSO;
+
 	public override void Awake(StateMachine stateMachine)
 	{
 	}
-		
+	
 	protected override bool Statement()
 	{
 		return true;
 	}
 	
-	// public override void OnStateEnter()
-	// {
-	// }
+	public override void OnStateEnter()
+	{
+	}
 	
-	// public override void OnStateExit()
-	// {
-	// }
+	public override void OnStateExit()
+	{
+	}
 }

--- a/UOP1_Project/Assets/Scripts/StateMachine/Editor/TransitionTableEditor.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Editor/TransitionTableEditor.cs
@@ -84,7 +84,7 @@ namespace UOP1.StateMachine.Editor
 			EditorGUILayout.HelpBox("Click on any State's name to see the Transitions it contains, or click the Pencil/Wrench icon to see its Actions.", MessageType.Info);
 			Separator();
 
-			serializedObject.UpdateIfRequiredOrScript();
+			ResetIfRequired();
 
 			// For each fromState
 			for (int i = 0; i < _fromStates.Count; i++)

--- a/UOP1_Project/Assets/Scripts/StateMachine/Editor/TransitionTableEditor.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Editor/TransitionTableEditor.cs
@@ -132,12 +132,7 @@ namespace UOP1.StateMachine.Editor
 						// Switch to state editor
 						if (Button(buttonRect, "SceneViewTools"))
 						{
-							if (_cachedStateEditor == null)
-								_cachedStateEditor = CreateEditor(transitions[0].SerializedTransition.FromState.objectReferenceValue, typeof(StateEditor));
-							else
-								CreateCachedEditor(transitions[0].SerializedTransition.FromState.objectReferenceValue, typeof(StateEditor), ref _cachedStateEditor);
-
-							_displayStateEditor = true;
+							DisplayStateEditor(transitions[0].SerializedTransition.FromState.objectReferenceValue);
 							return;
 						}
 
@@ -191,6 +186,16 @@ namespace UOP1.StateMachine.Editor
 			_addTransitionHelper.Display(rect);
 
 			EndHorizontal();
+		}
+
+		internal void DisplayStateEditor(Object state)
+		{
+			if (_cachedStateEditor == null)
+				_cachedStateEditor = CreateEditor(state, typeof(StateEditor));
+			else
+				CreateCachedEditor(state, typeof(StateEditor), ref _cachedStateEditor);
+
+			_displayStateEditor = true;
 		}
 
 		/// <summary>

--- a/UOP1_Project/Assets/Scripts/StateMachine/Editor/TransitionTableEditor.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Editor/TransitionTableEditor.cs
@@ -232,9 +232,9 @@ namespace UOP1.StateMachine.Editor
 			int transitionIndex = transitions[0].SerializedTransition.Index;
 			int targetIndex = _transitionsByFromStates[index - 1][0].SerializedTransition.Index;
 			_transitions.MoveArrayElement(transitionIndex, targetIndex);
-			
+
 			ApplyModifications($"Moved {_fromStates[index].name} State {(up ? "up" : "down")}");
-			
+
 			if (toggledState)
 				_toggledIndex = _fromStates.IndexOf(toggledState);
 		}

--- a/UOP1_Project/Assets/Scripts/StateMachine/Editor/TransitionTableEditor.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Editor/TransitionTableEditor.cs
@@ -19,7 +19,7 @@ namespace UOP1.StateMachine.Editor
 		private List<List<TransitionDisplayHelper>> _transitionsByFromStates;
 
 		// Index of the state currently toggled on, -1 if none is.
-		private int _toggledIndex = -1;
+		internal int _toggledIndex = -1;
 
 		// Helper class to add new transitions.
 		private AddTransitionHelper _addTransitionHelper;
@@ -46,9 +46,12 @@ namespace UOP1.StateMachine.Editor
 		/// </summary>
 		internal void Reset()
 		{
+			Object toggledState = null;
+			if (_toggledIndex > -1)
+				toggledState = _fromStates[_toggledIndex];
 			_transitions = serializedObject.FindProperty("_transitions");
 			GroupByFromState();
-			_toggledIndex = -1;
+			_toggledIndex = toggledState ? _fromStates.IndexOf(toggledState) : -1;
 		}
 
 		public override void OnInspectorGUI()
@@ -64,8 +67,12 @@ namespace UOP1.StateMachine.Editor
 			Separator();
 
 			// Back button
-			if (GUILayout.Button(EditorGUIUtility.IconContent("scrollleft"), GUILayout.Width(35), GUILayout.Height(20)))
+			if (GUILayout.Button(EditorGUIUtility.IconContent("scrollleft"), GUILayout.Width(35), GUILayout.Height(20))
+				|| _cachedStateEditor.serializedObject == null)
+			{
 				_displayStateEditor = false;
+				return;
+			}
 
 
 			Separator();

--- a/UOP1_Project/Assets/Scripts/StateMachine/Editor/TransitionTableEditorWindow.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Editor/TransitionTableEditorWindow.cs
@@ -37,6 +37,19 @@ namespace UOP1.StateMachine.Editor
 			rootVisualElement.styleSheets.Add(styleSheet);
 
 			minSize = new Vector2(480, 360);
+
+			EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+		}
+
+		private void OnDisable()
+		{
+			EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+		}
+
+		private void OnPlayModeStateChanged(PlayModeStateChange obj)
+		{
+			if (obj == PlayModeStateChange.EnteredPlayMode)
+				_doRefresh = true;
 		}
 
 		/// <summary>
@@ -85,7 +98,11 @@ namespace UOP1.StateMachine.Editor
 			listView.bindItem = (element, i) => ((Label)element).text = assets[i].name;
 			listView.selectionType = SelectionType.Single;
 
+			listView.onSelectionChanged -= OnListSelectionChanged;
 			listView.onSelectionChanged += OnListSelectionChanged;
+
+			if (_transitionTableEditor && _transitionTableEditor.target)
+				listView.selectedIndex = System.Array.IndexOf(assets, _transitionTableEditor.target);
 		}
 
 		private void OnListSelectionChanged(List<object> list)
@@ -102,7 +119,7 @@ namespace UOP1.StateMachine.Editor
 
 			if (_transitionTableEditor == null)
 				_transitionTableEditor = UnityEditor.Editor.CreateEditor(table, typeof(TransitionTableEditor));
-			else
+			else if (_transitionTableEditor.target != table)
 				UnityEditor.Editor.CreateCachedEditor(table, typeof(TransitionTableEditor), ref _transitionTableEditor);
 
 			editor.onGUIHandler = () =>

--- a/UOP1_Project/Assets/Scripts/StateMachine/Editor/Utilities/AddTransitionHelper.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Editor/Utilities/AddTransitionHelper.cs
@@ -26,6 +26,8 @@ namespace UOP1.StateMachine.Editor
 
 		internal void Display(Rect position)
 		{
+			position.x += 8;
+			position.width -= 16;
 			var rect = position;
 			float listHeight = _list.GetHeight();
 			float singleLineHeight = EditorGUIUtility.singleLineHeight;
@@ -59,18 +61,18 @@ namespace UOP1.StateMachine.Editor
 			// State Fields
 			{
 				position.y += 10;
-				position.x += 25;
+				position.x += 20;
 				StatePropField(position, "From", SerializedTransition.FromState);
-				position.x = rect.width / 2 + 25;
+				position.x = rect.width / 2 + 20;
 				StatePropField(position, "To", SerializedTransition.ToState);
 			}
 
 			// Conditions List
 			{
 				position.y += 30;
-				position.x = rect.x + 10;
+				position.x = rect.x + 5;
 				position.height = listHeight;
-				position.width -= 20;
+				position.width -= 10;
 				_list.DoList(position);
 			}
 

--- a/UOP1_Project/Assets/Scripts/StateMachine/Editor/Utilities/ContentStyle.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Editor/Utilities/ContentStyle.cs
@@ -30,8 +30,8 @@ namespace UOP1.StateMachine.Editor
 
 			DarkGray = EditorGUIUtility.isProSkin ? new Color(0.283f, 0.283f, 0.283f) : new Color(0.7f, 0.7f, 0.7f);
 			LightGray = EditorGUIUtility.isProSkin ? new Color(0.33f, 0.33f, 0.33f) : new Color(0.8f, 0.8f, 0.8f);
-			ZebraDark = new Color(0.1f, 0.5f, 0.9f, 0.1f);
-			ZebraLight = new Color(0.8f, 0.8f, 0.9f, 0.1f);
+			ZebraDark = new Color(0.4f, 0.4f, 0.4f, 0.1f);
+			ZebraLight = new Color(0.8f, 0.8f, 0.8f, 0.1f);
 			Focused = new Color(0.5f, 0.5f, 0.5f, 0.5f);
 			Padding = new RectOffset(5, 5, 5, 5);
 			LeftPadding = new RectOffset(10, 0, 0, 0);

--- a/UOP1_Project/Assets/Scripts/StateMachine/Editor/Utilities/TransitionDisplayHelper.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Editor/Utilities/TransitionDisplayHelper.cs
@@ -54,11 +54,44 @@ namespace UOP1.StateMachine.Editor
 			{
 				bool Button(Rect pos, string icon) => GUI.Button(pos, EditorGUIUtility.IconContent(icon));
 
-				var buttonRect = new Rect(
-					x: rect.width - 125,
-					y: rect.y + 5,
-					width: 30,
-					height: 18);
+				var buttonRect = new Rect(x: rect.width - 25, y: rect.y + 5, width: 30, height: 18);
+
+				int i, l;
+				{
+					var transitions = _editor.GetStateTransitions(SerializedTransition.FromState.objectReferenceValue);
+					l = transitions.Count - 1;
+					i = transitions.FindIndex(t => t.Index == SerializedTransition.Index);
+				}
+
+				// Remove transition
+				if (Button(buttonRect, "Toolbar Minus"))
+				{
+					_editor.RemoveTransition(SerializedTransition);
+					return true;
+				}
+				buttonRect.x -= 35;
+
+				// Move transition down
+				if (i < l)
+				{
+					if (Button(buttonRect, "scrolldown"))
+					{
+						_editor.ReorderTransition(SerializedTransition, false);
+						return true;
+					}
+					buttonRect.x -= 35;
+				}
+
+				// Move transition up
+				if (i > 0)
+				{
+					if (Button(buttonRect, "scrollup"))
+					{
+						_editor.ReorderTransition(SerializedTransition, true);
+						return true;
+					}
+					buttonRect.x -= 35;
+				}
 
 				// State editor
 				if (Button(buttonRect, "SceneViewTools"))
@@ -66,31 +99,7 @@ namespace UOP1.StateMachine.Editor
 					_editor.DisplayStateEditor(SerializedTransition.ToState.objectReferenceValue);
 					return true;
 				}
-
-				buttonRect.x += 35;
-
-				// Move transition up
-				if (Button(buttonRect, "scrollup"))
-					if (_editor.ReorderTransition(SerializedTransition, true))
-						return true;
-
-				buttonRect.x += 35;
-
-				// Move transition down
-				if (Button(buttonRect, "scrolldown"))
-					if (_editor.ReorderTransition(SerializedTransition, false))
-						return true;
-
-				buttonRect.x += 35;
-
-				// Remove transition
-				if (Button(buttonRect, "Toolbar Minus"))
-				{
-					_editor.RemoveTransition(SerializedTransition.Index);
-					return true;
-				}
 			}
-
 
 			rect.x = position.x + 5;
 			rect.y += rect.height;

--- a/UOP1_Project/Assets/Scripts/StateMachine/Editor/Utilities/TransitionDisplayHelper.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Editor/Utilities/TransitionDisplayHelper.cs
@@ -55,11 +55,20 @@ namespace UOP1.StateMachine.Editor
 				bool Button(Rect pos, string icon) => GUI.Button(pos, EditorGUIUtility.IconContent(icon));
 
 				var buttonRect = new Rect(
-					x: rect.width - 90,
+					x: rect.width - 125,
 					y: rect.y + 5,
 					width: 30,
 					height: 18);
 
+				// State editor
+				if (Button(buttonRect, "SceneViewTools"))
+				{
+					_editor.DisplayStateEditor(SerializedTransition.ToState.objectReferenceValue);
+					return true;
+				}
+
+				buttonRect.x += 35;
+				
 				// Move transition up
 				if (Button(buttonRect, "scrollup"))
 					if (_editor.ReorderTransition(SerializedTransition, true))

--- a/UOP1_Project/Assets/Scripts/StateMachine/Editor/Utilities/TransitionDisplayHelper.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Editor/Utilities/TransitionDisplayHelper.cs
@@ -68,7 +68,7 @@ namespace UOP1.StateMachine.Editor
 				}
 
 				buttonRect.x += 35;
-				
+
 				// Move transition up
 				if (Button(buttonRect, "scrollup"))
 					if (_editor.ReorderTransition(SerializedTransition, true))


### PR DESCRIPTION
[Generic State Machine](https://forum.unity.com/threads/generic-state-machine.979371/)

Mainly subtle changes that should make the TransitionTable editor feel better to use.

No changes to the functionality of State Machines, except for moving the call to method `OnStateEnter` of the initial State from the StateMachine's `Awake` to `Start`. This change didn't affect any of the currently implemented State Machines, but it makes more sense and prevents possible bugs down the line. This is because a lot of things get set up during `Awake`. If, say, in `OnStateEnter` we access a field in an **MB** that gets assigned during that **MB**'s `Awake`, but because of execution order the StateMachine's `Awake` gets called before that happens, we would get seemingly random exceptions and undesired behavior.

In this picture, you can see the visual changes to the editor.

![image](https://user-images.githubusercontent.com/27371812/104827903-fdda6900-5841-11eb-95da-79b0c674629f.png)
Highlighted, from top to bottom:
1. States and transitions will only show the up/down buttons when they can move up or down (the first item in a list can't move up, as well as the last item cannot move further down).
2. Added buttons to edit 'To States' in the Transition Table Editor, just like with 'From States'.
3. Changed reorderable list accent color from light blue to a darker grey.

There were also changes to script templates, editor stability improvements, and bug fixes. Please check out the description of each commit for a full list of changes.

As always, feedback and further suggestions are very welcomed.