### PR TITLE
Add a Stop and Finish option for the AudioManager

### DIFF
--- a/UOP1_Project/Assets/Scripts/Audio/AudioCue.cs
+++ b/UOP1_Project/Assets/Scripts/Audio/AudioCue.cs
@@ -16,6 +16,8 @@ public class AudioCue : MonoBehaviour
 	[SerializeField] private AudioCueEventChannelSO _audioCueEventChannel = default;
 	[SerializeField] private AudioConfigurationSO _audioConfiguration = default;
 
+	private AudioCueKey controlKey = AudioCueKey.Invalid;
+
 	private void Start()
 	{
 		if (_playOnStart)
@@ -31,6 +33,28 @@ public class AudioCue : MonoBehaviour
 
 	public void PlayAudioCue()
 	{
-		_audioCueEventChannel.RaiseEvent(_audioCue, _audioConfiguration, transform.position);
+		controlKey = _audioCueEventChannel.RaisePlayEvent(_audioCue, _audioConfiguration, transform.position);
+	}
+
+	public void StopAudioCue()
+	{
+		if (controlKey != AudioCueKey.Invalid)
+		{
+			if (!_audioCueEventChannel.RaiseStopEvent(controlKey))
+			{
+				controlKey = AudioCueKey.Invalid;
+			}
+		}
+	}
+
+	public void FinishAudioCue()
+	{
+		if (controlKey != AudioCueKey.Invalid)
+		{
+			if (!_audioCueEventChannel.RaiseFinishEvent(controlKey))
+			{
+				controlKey = AudioCueKey.Invalid;
+			}
+		}
 	}
 }

--- a/UOP1_Project/Assets/Scripts/Audio/AudioCueOnTriggerEnterTest.cs
+++ b/UOP1_Project/Assets/Scripts/Audio/AudioCueOnTriggerEnterTest.cs
@@ -1,0 +1,40 @@
+﻿using UnityEngine;
+using System.Collections;
+
+namespace Assets.Scripts.Audio
+{
+	/// <summary>
+	/// Class to activate AudioCues when a GameObject (i.e. the Player) enters the trigger Collider on this same GameObject.
+	/// This component is mostly used for testing purposes.
+	/// </summary>
+	[RequireComponent(typeof(AudioCue))]
+	public class AudioCueOnTriggerEnterTest : MonoBehaviour
+	{
+		[SerializeField] private bool _isInstantStop = true;
+		[SerializeField] private string _tagToDetect = "Player";
+
+		private AudioCue audioCue;
+
+		private void Awake()
+		{
+			audioCue = GetComponent<AudioCue>();
+		}
+
+		private void OnTriggerEnter(Collider other)
+		{
+			if (other.gameObject.CompareTag(_tagToDetect))
+				audioCue.PlayAudioCue();
+		}
+
+		private void OnTriggerExit(Collider other)
+		{
+			if (other.gameObject.CompareTag(_tagToDetect))
+			{
+				if (_isInstantStop)
+					audioCue.StopAudioCue();
+				else
+					audioCue.FinishAudioCue();
+			}
+		}
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Audio/AudioCueOnTriggerEnterTest.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Audio/AudioCueOnTriggerEnterTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66826bab8510986499959f229b88770c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Audio/AudioData/AudioCueKey.cs
+++ b/UOP1_Project/Assets/Scripts/Audio/AudioData/AudioCueKey.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+public struct AudioCueKey
+{
+	public static AudioCueKey Invalid = new AudioCueKey(-1, null);
+
+	internal int Value;
+	internal AudioCueSO AudioCue;
+
+	internal AudioCueKey(int value, AudioCueSO audioCue)
+	{
+		Value = value;
+		AudioCue = audioCue;
+	}
+
+	public override bool Equals(Object obj)
+	{
+		return obj is AudioCueKey x && Value == x.Value && AudioCue == x.AudioCue;
+	}
+	public override int GetHashCode()
+	{
+		return Value.GetHashCode() ^ AudioCue.GetHashCode();
+	}
+	public static bool operator ==(AudioCueKey x, AudioCueKey y)
+	{
+		return x.Value == y.Value && x.AudioCue == y.AudioCue;
+	}
+	public static bool operator !=(AudioCueKey x, AudioCueKey y)
+	{
+		return !(x == y);
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Audio/AudioData/AudioCueKey.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Audio/AudioData/AudioCueKey.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 325f637f904634344bb44ab93b38e81e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Audio/AudioManager.cs
+++ b/UOP1_Project/Assets/Scripts/Audio/AudioManager.cs
@@ -27,15 +27,24 @@ public class AudioManager : MonoBehaviour
 	[Range(0f, 1f)]
 	[SerializeField] private float _sfxVolume = 1f;
 
+	private SoundEmitterList _soundEmitterList;
+
 	private void Awake()
 	{
 		//TODO: Get the initial volume levels from the settings
+		_soundEmitterList = new SoundEmitterList();
 
-		_SFXEventChannel.OnAudioCueRequested += PlayAudioCue;
-		_musicEventChannel.OnAudioCueRequested += PlayAudioCue; //TODO: Treat music requests differently?
+		RegisterChannel(_SFXEventChannel);
+		RegisterChannel(_musicEventChannel); //TODO: Treat music requests differently?
 
 		_pool.Prewarm(_initialSize);
 		_pool.SetParent(this.transform);
+	}
+
+	private void OnDestroy()
+	{
+		UnregisterChannel(_SFXEventChannel);
+		UnregisterChannel(_musicEventChannel);
 	}
 
 	/// <summary>
@@ -72,6 +81,20 @@ public class AudioManager : MonoBehaviour
 		}
 	}
 
+	private void RegisterChannel(AudioCueEventChannelSO audioCueEventChannel)
+	{
+		audioCueEventChannel.OnAudioCuePlayRequested += PlayAudioCue;
+		audioCueEventChannel.OnAudioCueStopRequested += StopAudioCue;
+		audioCueEventChannel.OnAudioCueFinishRequested += FinishAudioCue;
+	}
+
+	private void UnregisterChannel(AudioCueEventChannelSO audioCueEventChannel)
+	{
+		audioCueEventChannel.OnAudioCuePlayRequested += PlayAudioCue;
+		audioCueEventChannel.OnAudioCueStopRequested += StopAudioCue;
+		audioCueEventChannel.OnAudioCueFinishRequested += FinishAudioCue;
+	}
+
 	// Both MixerValueNormalized and NormalizedToMixerValue functions are used for easier transformations
 	/// when using UI sliders normalized format
 	private float MixerValueToNormalized(float mixerValue)
@@ -89,28 +112,69 @@ public class AudioManager : MonoBehaviour
 	/// <summary>
 	/// Plays an AudioCue by requesting the appropriate number of SoundEmitters from the pool.
 	/// </summary>
-	public void PlayAudioCue(AudioCueSO audioCue, AudioConfigurationSO settings, Vector3 position = default)
+	public AudioCueKey PlayAudioCue(AudioCueSO audioCue, AudioConfigurationSO settings, Vector3 position = default)
 	{
 		AudioClip[] clipsToPlay = audioCue.GetClips();
-		int nOfClips = clipsToPlay.Length;
+		SoundEmitter[] soundEmitterArray = new SoundEmitter[clipsToPlay.Length];
 
+		int nOfClips = clipsToPlay.Length;
 		for (int i = 0; i < nOfClips; i++)
 		{
-			SoundEmitter soundEmitter = _pool.Request();
-			if (soundEmitter != null)
+			soundEmitterArray[i] = _pool.Request();
+			if (soundEmitterArray[i] != null)
 			{
-				soundEmitter.PlayAudioClip(clipsToPlay[i], settings, audioCue.looping, position);
+				soundEmitterArray[i].PlayAudioClip(clipsToPlay[i], settings, audioCue.looping, position);
 				if (!audioCue.looping)
-					soundEmitter.OnSoundFinishedPlaying += OnSoundEmitterFinishedPlaying;
+					soundEmitterArray[i].OnSoundFinishedPlaying += OnSoundEmitterFinishedPlaying;
 			}
 		}
 
-		//TODO: Save the SoundEmitters that were activated, to be able to stop them if needed
+		return _soundEmitterList.Add(audioCue, soundEmitterArray);
+	}
+
+	public bool FinishAudioCue(AudioCueKey emitterKey)
+	{
+		bool isFound = _soundEmitterList.Get(emitterKey, out SoundEmitter[] soundEmitters);
+
+		if (isFound)
+		{
+			for (int i = 0; i < soundEmitters.Length; i++)
+			{
+				soundEmitters[i].Finish();
+				soundEmitters[i].OnSoundFinishedPlaying += OnSoundEmitterFinishedPlaying;
+			}		
+		}
+
+		return isFound;
+	}
+
+	public bool StopAudioCue(AudioCueKey emitterKey)
+	{
+		bool isFound = _soundEmitterList.Get(emitterKey, out SoundEmitter[] soundEmitters);
+
+		if (isFound)
+		{
+			for (int i = 0; i < soundEmitters.Length; i++)
+			{
+				StopAndCleanEmitter(soundEmitters[i]);
+			}
+
+			_soundEmitterList.Remove(emitterKey);
+		}
+
+		return isFound;
 	}
 
 	private void OnSoundEmitterFinishedPlaying(SoundEmitter soundEmitter)
 	{
-		soundEmitter.OnSoundFinishedPlaying -= OnSoundEmitterFinishedPlaying;
+		StopAndCleanEmitter(soundEmitter);
+	}
+
+	private void StopAndCleanEmitter(SoundEmitter soundEmitter)
+	{
+		if(soundEmitter.IsFinishing())
+			soundEmitter.OnSoundFinishedPlaying -= OnSoundEmitterFinishedPlaying;
+
 		soundEmitter.Stop();
 		_pool.Return(soundEmitter);
 	}

--- a/UOP1_Project/Assets/Scripts/Audio/SoundEmitters/SoundEmitter.cs
+++ b/UOP1_Project/Assets/Scripts/Audio/SoundEmitters/SoundEmitter.cs
@@ -60,6 +60,16 @@ public class SoundEmitter : MonoBehaviour
 		_audioSource.Stop();
 	}
 
+	public void Finish()
+	{
+		if (_audioSource.loop)
+		{
+			_audioSource.loop = false;
+			float timeRemaining = _audioSource.clip.length - _audioSource.time;
+			StartCoroutine(FinishedPlaying(timeRemaining));
+		}
+	}
+
 	public bool IsInUse()
 	{
 		return _audioSource.isPlaying;
@@ -68,6 +78,11 @@ public class SoundEmitter : MonoBehaviour
 	public bool IsLooping()
 	{
 		return _audioSource.loop;
+	}
+
+	public bool IsFinishing()
+	{
+		return !_audioSource.loop;
 	}
 
 	IEnumerator FinishedPlaying(float clipLength)

--- a/UOP1_Project/Assets/Scripts/Audio/SoundEmitters/SoundEmitterList.cs
+++ b/UOP1_Project/Assets/Scripts/Audio/SoundEmitters/SoundEmitterList.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine.Assertions;
+
+public class SoundEmitterList
+{
+	private int _nextUniqueKey = 0;
+	private List<AudioCueKey> _emittersKey;
+	private List<SoundEmitter[]> _emittersList;
+
+	public SoundEmitterList()
+	{
+		_emittersKey = new List<AudioCueKey>();
+		_emittersList = new List<SoundEmitter[]>();
+	}
+
+	public AudioCueKey GetKey(AudioCueSO cue)
+	{
+		return new AudioCueKey(_nextUniqueKey++, cue);
+	}
+
+	public void Add(AudioCueKey key, SoundEmitter[] emitter)
+	{
+		_emittersKey.Add(key);
+		_emittersList.Add(emitter);
+	}
+
+	public AudioCueKey Add(AudioCueSO cue, SoundEmitter[] emitter)
+	{
+		AudioCueKey emitterKey = GetKey(cue);
+
+		_emittersKey.Add(emitterKey);
+		_emittersList.Add(emitter);
+
+		return emitterKey;
+	}
+
+	public bool Get(AudioCueKey key, out SoundEmitter[] emitter)
+	{
+		int index = _emittersKey.FindIndex(x => x == key);
+
+		if (index < 0)
+		{
+			emitter = null;
+			return false;
+		}
+
+		emitter = _emittersList[index];
+		return true;
+	}
+
+	public bool Remove(AudioCueKey key)
+	{
+		int index = _emittersKey.FindIndex(x => x == key);
+		return RemoveAt(index);
+	}
+
+	private bool RemoveAt(int index)
+	{
+		if (index < 0)
+		{
+			return false;
+		}
+
+		_emittersKey.RemoveAt(index);
+		_emittersList.RemoveAt(index);
+
+		return true;
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Audio/SoundEmitters/SoundEmitterList.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Audio/SoundEmitters/SoundEmitterList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d1a0455c3126ea4a991e9fd36520393
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Characters/ProtagonistAudio.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/ProtagonistAudio.cs
@@ -9,7 +9,7 @@ public class ProtagonistAudio : MonoBehaviour
 
 	[SerializeField] private AudioCueSO caneSwing, objectPickup, footstep;
 
-	public void PlayFootstep() => _sfxEventChannel.RaiseEvent(footstep, _audioConfig, transform.position);
-	public void PlayCaneSwing() => _sfxEventChannel.RaiseEvent(caneSwing, _audioConfig, transform.position);
-	public void PlayObjectPickup() => _sfxEventChannel.RaiseEvent(objectPickup, _audioConfig, transform.position);
+	public void PlayFootstep() => _sfxEventChannel.RaisePlayEvent(footstep, _audioConfig, transform.position);
+	public void PlayCaneSwing() => _sfxEventChannel.RaisePlayEvent(caneSwing, _audioConfig, transform.position);
+	public void PlayObjectPickup() => _sfxEventChannel.RaisePlayEvent(objectPickup, _audioConfig, transform.position);
 }

--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/PlayAudioCueActionSO.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/PlayAudioCueActionSO.cs
@@ -27,6 +27,6 @@ public class PlayAudioCueAction : StateAction
 
 	public override void OnStateEnter()
 	{
-		_originSO.audioCueEventChannel.RaiseEvent(_originSO.audioCue, _originSO.audioConfiguration, _stateMachineTransform.position);
+		_originSO.audioCueEventChannel.RaisePlayEvent(_originSO.audioCue, _originSO.audioConfiguration, _stateMachineTransform.position);
 	}
 }

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/AudioCueEventChannelSO.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/AudioCueEventChannelSO.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using System.Collections;
 using UnityEngine.Events;
+using System.Collections.Generic;
 
 /// <summary>
 /// Event on which <c>AudioCue</c> components send a message to play SFX and music. <c>AudioManager</c> listens on these events, and actually plays the sound.
@@ -8,19 +9,65 @@ using UnityEngine.Events;
 [CreateAssetMenu(menuName = "Events/AudioCue Event Channel")]
 public class AudioCueEventChannelSO : EventChannelBaseSO
 {
-	public UnityAction<AudioCueSO, AudioConfigurationSO, Vector3> OnAudioCueRequested;
+	public AudioCuePlayAction OnAudioCuePlayRequested;
+	public AudioCueStopAction OnAudioCueStopRequested;
+	public AudioCueFinishAction OnAudioCueFinishRequested;
 
-	public void RaiseEvent(AudioCueSO audioCue, AudioConfigurationSO audioConfiguration, Vector3 positionInSpace)
+	public AudioCueKey RaisePlayEvent(AudioCueSO audioCue, AudioConfigurationSO audioConfiguration, Vector3 positionInSpace)
 	{
-		if (OnAudioCueRequested != null)
+		AudioCueKey audioCueKey = AudioCueKey.Invalid;
+
+		if (OnAudioCuePlayRequested != null)
 		{
-			OnAudioCueRequested.Invoke(audioCue, audioConfiguration, positionInSpace);
+			audioCueKey = OnAudioCuePlayRequested.Invoke(audioCue, audioConfiguration, positionInSpace);
 		}
 		else
 		{
-			Debug.LogWarning("An AudioCue was requested, but nobody picked it up. " +
+			Debug.LogWarning("An AudioCue play event was requested, but nobody picked it up. " +
 				"Check why there is no AudioManager already loaded, " +
 				"and make sure it's listening on this AudioCue Event channel.");
 		}
+
+		return audioCueKey;
+	}
+
+	public bool RaiseStopEvent(AudioCueKey audioCueKey)
+	{
+		bool requestSucceed = false;
+
+		if (OnAudioCueStopRequested != null)
+		{
+			requestSucceed = OnAudioCueStopRequested.Invoke(audioCueKey);
+		}
+		else
+		{
+			Debug.LogWarning("An AudioCue stop event was requested, but nobody picked it up. " +
+				"Check why there is no AudioManager already loaded, " +
+				"and make sure it's listening on this AudioCue Event channel.");
+		}
+
+		return requestSucceed;
+	}
+
+	public bool RaiseFinishEvent(AudioCueKey audioCueKey)
+	{
+		bool requestSucceed = false;
+
+		if (OnAudioCueStopRequested != null)
+		{
+			requestSucceed = OnAudioCueFinishRequested.Invoke(audioCueKey);
+		}
+		else
+		{
+			Debug.LogWarning("An AudioCue finish event was requested, but nobody picked it up. " +
+				"Check why there is no AudioManager already loaded, " +
+				"and make sure it's listening on this AudioCue Event channel.");
+		}
+
+		return requestSucceed;
 	}
 }
+
+public delegate AudioCueKey AudioCuePlayAction(AudioCueSO audioCue, AudioConfigurationSO audioConfiguration, Vector3 positionInSpace);
+public delegate bool AudioCueStopAction(AudioCueKey emitterKey);
+public delegate bool AudioCueFinishAction(AudioCueKey emitterKey);


### PR DESCRIPTION
Forum thread: None
Codecks card: [Audio: Stop vs. FinishAndStop](https://open.codecks.io/unity-open-project-1/decks/15-code/card/19f-audio-stop-vs-finishandstop)

Add the feature to control the audio played
Did some modification in the AudioManager and AudioEventChannel

Noticeable feature:
- You get an AudioCueKey when you request playing audio
- You can use this key to either stop or finish the emitters from the previous request.
- Stop end the audio instantly and Finish stop at the end of the audio clip

[Video](https://streamable.com/0ozroq)

I chose to use a key to control the emitter to avoid using a emitter that has been put back into the pool. The alternative was to let the user do the pooling. I find the first option cleaner. In any case, can't wait to hear your opinion. 