### PR TITLE
Input is cached when not immediately consumed by a State

### DIFF
--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/PigChef_TransitionTable.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/PigChef_TransitionTable.asset
@@ -136,3 +136,9 @@ MonoBehaviour:
     - ExpectedResult: 0
       Condition: {fileID: 11400000, guid: 2bfa25e0277246b4ba0ea0117c40c18b, type: 2}
       Operator: 0
+  - FromState: {fileID: 11400000, guid: 027d32476800b3543b2f5446a59054c8, type: 2}
+    ToState: {fileID: 11400000, guid: ff92a93d8a8694247b507d811c88e402, type: 2}
+    Conditions:
+    - ExpectedResult: 0
+      Condition: {fileID: 11400000, guid: b33fba8c83df19f4ead430fbcc728687, type: 2}
+      Operator: 0

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/Talk.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/Talk.asset
@@ -13,5 +13,6 @@ MonoBehaviour:
   m_Name: Talk
   m_EditorClassIdentifier: 
   _actions:
+  - {fileID: 11400000, guid: c0d0573a78e4c6245ab9676e7af35880, type: 2}
   - {fileID: 11400000, guid: 7ad91f04f328d9d42a677833fa39748d, type: 2}
   - {fileID: 11400000, guid: 1cbeab9d369d57546a33afac8ca7810f, type: 2}


### PR DESCRIPTION
I made two little changes on State Machine.

1st change - Walking State:
I added a transition to Talk State when player will talk to someone and not in proccess of jump.

2nd change - Talking State:
I added more one action to disable player walking.
 
https://github.com/UnityTechnologies/open-project-1/issues/297
https://forum.unity.com/threads/input-cached-when-not-immediately-consumed-by-a-state.1022698/
I changed the logic of State Machine to stop the player's movement when him start to talk with someone.
Open a testing scene, press Play.
While walking or jumping, press the ExtraActionButton ("L" on keyboard, "Button North" on gamepad).