### PR TITLE
Fix Input is cached when not immediately consumed by a State for jump…

### DIFF
--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/PigChef_TransitionTable.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/PigChef_TransitionTable.asset
@@ -50,22 +50,19 @@ MonoBehaviour:
       Condition: {fileID: 11400000, guid: 41dbff2af0b6f7141a32bb464309ba69, type: 2}
       Operator: 0
   - FromState: {fileID: 11400000, guid: c57ed1dc57a890943b2648ca8a581075, type: 2}
-    ToState: {fileID: 11400000, guid: 027d32476800b3543b2f5446a59054c8, type: 2}
+    ToState: {fileID: 11400000, guid: 390bddf5271c3024b8a375a0a62d0990, type: 2}
     Conditions:
-    - ExpectedResult: 0
-      Condition: {fileID: 11400000, guid: c7258bdb2558a214f916c8b5b3c0fa1f, type: 2}
-      Operator: 0
-    - ExpectedResult: 0
-      Condition: {fileID: 11400000, guid: a79b812272ab8314aa305b39f9a2740a, type: 2}
-      Operator: 0
-  - FromState: {fileID: 11400000, guid: c57ed1dc57a890943b2648ca8a581075, type: 2}
-    ToState: {fileID: 11400000, guid: e128814ff6dbf63449bbc4dc8b6dc066, type: 2}
-    Conditions:
-    - ExpectedResult: 0
-      Condition: {fileID: 11400000, guid: c7258bdb2558a214f916c8b5b3c0fa1f, type: 2}
+    - ExpectedResult: 1
+      Condition: {fileID: 11400000, guid: ac445a33a0d072a4b96458c8ea343d49, type: 2}
       Operator: 0
     - ExpectedResult: 1
-      Condition: {fileID: 11400000, guid: a79b812272ab8314aa305b39f9a2740a, type: 2}
+      Condition: {fileID: 11400000, guid: b33fba8c83df19f4ead430fbcc728687, type: 2}
+      Operator: 0
+    - ExpectedResult: 1
+      Condition: {fileID: 11400000, guid: 9c4a0f8b97247c643aef1b1284f21ebc, type: 2}
+      Operator: 0
+    - ExpectedResult: 1
+      Condition: {fileID: 11400000, guid: 620f4efd93744084a8ac9ba272f093dc, type: 2}
       Operator: 0
   - FromState: {fileID: 11400000, guid: 027d32476800b3543b2f5446a59054c8, type: 2}
     ToState: {fileID: 11400000, guid: c57ed1dc57a890943b2648ca8a581075, type: 2}
@@ -177,6 +174,12 @@ MonoBehaviour:
     Conditions:
     - ExpectedResult: 1
       Condition: {fileID: 11400000, guid: a79b812272ab8314aa305b39f9a2740a, type: 2}
+      Operator: 1
+  - FromState: {fileID: 11400000, guid: 390bddf5271c3024b8a375a0a62d0990, type: 2}
+    ToState: {fileID: 11400000, guid: c57ed1dc57a890943b2648ca8a581075, type: 2}
+    Conditions:
+    - ExpectedResult: 1
+      Condition: {fileID: 11400000, guid: c7258bdb2558a214f916c8b5b3c0fa1f, type: 2}
       Operator: 0
   - FromState: {fileID: 11400000, guid: bda8bfafdf35e3e4092bb96279d4894c, type: 2}
     ToState: {fileID: 11400000, guid: 856d49f6d9474464cb77059057f969a5, type: 2}
@@ -184,17 +187,17 @@ MonoBehaviour:
     - ExpectedResult: 0
       Condition: {fileID: 11400000, guid: 373ff606aeb23834eb964bdf9a6f6e3c, type: 2}
       Operator: 0
-    - ExpectedResult: 0
+    - ExpectedResult: 1
       Condition: {fileID: 11400000, guid: ac445a33a0d072a4b96458c8ea343d49, type: 2}
-      Operator: 1
-    - ExpectedResult: 0
+      Operator: 0
+    - ExpectedResult: 1
       Condition: {fileID: 11400000, guid: b33fba8c83df19f4ead430fbcc728687, type: 2}
-      Operator: 1
-    - ExpectedResult: 0
-      Condition: {fileID: 11400000, guid: 9c4a0f8b97247c643aef1b1284f21ebc, type: 2}
-      Operator: 1
-    - ExpectedResult: 0
+      Operator: 0
+    - ExpectedResult: 1
       Condition: {fileID: 11400000, guid: 620f4efd93744084a8ac9ba272f093dc, type: 2}
+      Operator: 0
+    - ExpectedResult: 1
+      Condition: {fileID: 11400000, guid: 9c4a0f8b97247c643aef1b1284f21ebc, type: 2}
       Operator: 0
   - FromState: {fileID: 11400000, guid: 027d32476800b3543b2f5446a59054c8, type: 2}
     ToState: {fileID: 11400000, guid: 78675b2bf031c3f4a9c28dda969298e2, type: 2}
@@ -220,31 +223,25 @@ MonoBehaviour:
     - ExpectedResult: 0
       Condition: {fileID: 11400000, guid: b5cf328bcf17e41469fda079c80b3c84, type: 2}
       Operator: 0
-  - FromState: {fileID: 11400000, guid: c57ed1dc57a890943b2648ca8a581075, type: 2}
-    ToState: {fileID: 11400000, guid: 390bddf5271c3024b8a375a0a62d0990, type: 2}
+  - FromState: {fileID: 11400000, guid: 856d49f6d9474464cb77059057f969a5, type: 2}
+    ToState: {fileID: 11400000, guid: 027d32476800b3543b2f5446a59054c8, type: 2}
     Conditions:
     - ExpectedResult: 0
-      Condition: {fileID: 11400000, guid: ac445a33a0d072a4b96458c8ea343d49, type: 2}
-      Operator: 1
-    - ExpectedResult: 0
-      Condition: {fileID: 11400000, guid: b33fba8c83df19f4ead430fbcc728687, type: 2}
-      Operator: 1
-    - ExpectedResult: 0
-      Condition: {fileID: 11400000, guid: 9c4a0f8b97247c643aef1b1284f21ebc, type: 2}
-      Operator: 1
-    - ExpectedResult: 0
-      Condition: {fileID: 11400000, guid: 620f4efd93744084a8ac9ba272f093dc, type: 2}
-      Operator: 1
-    - ExpectedResult: 0
-      Condition: {fileID: 11400000, guid: c7258bdb2558a214f916c8b5b3c0fa1f, type: 2}
+      Condition: {fileID: 11400000, guid: a79b812272ab8314aa305b39f9a2740a, type: 2}
       Operator: 0
   - FromState: {fileID: 11400000, guid: 390bddf5271c3024b8a375a0a62d0990, type: 2}
-    ToState: {fileID: 11400000, guid: c57ed1dc57a890943b2648ca8a581075, type: 2}
+    ToState: {fileID: 11400000, guid: 622df1fde8c210a439bbb2fcb2dbc4d2, type: 2}
     Conditions:
-    - ExpectedResult: 1
+    - ExpectedResult: 0
       Condition: {fileID: 11400000, guid: c7258bdb2558a214f916c8b5b3c0fa1f, type: 2}
       Operator: 0
-  - FromState: {fileID: 11400000, guid: 856d49f6d9474464cb77059057f969a5, type: 2}
+  - FromState: {fileID: 11400000, guid: 622df1fde8c210a439bbb2fcb2dbc4d2, type: 2}
+    ToState: {fileID: 11400000, guid: e128814ff6dbf63449bbc4dc8b6dc066, type: 2}
+    Conditions:
+    - ExpectedResult: 1
+      Condition: {fileID: 11400000, guid: a79b812272ab8314aa305b39f9a2740a, type: 2}
+      Operator: 0
+  - FromState: {fileID: 11400000, guid: 622df1fde8c210a439bbb2fcb2dbc4d2, type: 2}
     ToState: {fileID: 11400000, guid: 027d32476800b3543b2f5446a59054c8, type: 2}
     Conditions:
     - ExpectedResult: 0

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/PigChef_TransitionTable.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/PigChef_TransitionTable.asset
@@ -172,23 +172,29 @@ MonoBehaviour:
     - ExpectedResult: 0
       Condition: {fileID: 11400000, guid: 0222b854529fb8f418abda000d3b9b32, type: 2}
       Operator: 0
-  - FromState: {fileID: 11400000, guid: bda8bfafdf35e3e4092bb96279d4894c, type: 2}
-    ToState: {fileID: 11400000, guid: 027d32476800b3543b2f5446a59054c8, type: 2}
-    Conditions:
-    - ExpectedResult: 0
-      Condition: {fileID: 11400000, guid: 373ff606aeb23834eb964bdf9a6f6e3c, type: 2}
-      Operator: 0
-    - ExpectedResult: 0
-      Condition: {fileID: 11400000, guid: a79b812272ab8314aa305b39f9a2740a, type: 2}
-      Operator: 0
-  - FromState: {fileID: 11400000, guid: bda8bfafdf35e3e4092bb96279d4894c, type: 2}
+  - FromState: {fileID: 11400000, guid: 856d49f6d9474464cb77059057f969a5, type: 2}
     ToState: {fileID: 11400000, guid: e128814ff6dbf63449bbc4dc8b6dc066, type: 2}
     Conditions:
+    - ExpectedResult: 1
+      Condition: {fileID: 11400000, guid: a79b812272ab8314aa305b39f9a2740a, type: 2}
+      Operator: 0
+  - FromState: {fileID: 11400000, guid: bda8bfafdf35e3e4092bb96279d4894c, type: 2}
+    ToState: {fileID: 11400000, guid: 856d49f6d9474464cb77059057f969a5, type: 2}
+    Conditions:
     - ExpectedResult: 0
       Condition: {fileID: 11400000, guid: 373ff606aeb23834eb964bdf9a6f6e3c, type: 2}
       Operator: 0
-    - ExpectedResult: 1
-      Condition: {fileID: 11400000, guid: a79b812272ab8314aa305b39f9a2740a, type: 2}
+    - ExpectedResult: 0
+      Condition: {fileID: 11400000, guid: ac445a33a0d072a4b96458c8ea343d49, type: 2}
+      Operator: 1
+    - ExpectedResult: 0
+      Condition: {fileID: 11400000, guid: b33fba8c83df19f4ead430fbcc728687, type: 2}
+      Operator: 1
+    - ExpectedResult: 0
+      Condition: {fileID: 11400000, guid: 9c4a0f8b97247c643aef1b1284f21ebc, type: 2}
+      Operator: 1
+    - ExpectedResult: 0
+      Condition: {fileID: 11400000, guid: 620f4efd93744084a8ac9ba272f093dc, type: 2}
       Operator: 0
   - FromState: {fileID: 11400000, guid: 027d32476800b3543b2f5446a59054c8, type: 2}
     ToState: {fileID: 11400000, guid: 78675b2bf031c3f4a9c28dda969298e2, type: 2}
@@ -213,4 +219,34 @@ MonoBehaviour:
     Conditions:
     - ExpectedResult: 0
       Condition: {fileID: 11400000, guid: b5cf328bcf17e41469fda079c80b3c84, type: 2}
+      Operator: 0
+  - FromState: {fileID: 11400000, guid: c57ed1dc57a890943b2648ca8a581075, type: 2}
+    ToState: {fileID: 11400000, guid: 390bddf5271c3024b8a375a0a62d0990, type: 2}
+    Conditions:
+    - ExpectedResult: 0
+      Condition: {fileID: 11400000, guid: ac445a33a0d072a4b96458c8ea343d49, type: 2}
+      Operator: 1
+    - ExpectedResult: 0
+      Condition: {fileID: 11400000, guid: b33fba8c83df19f4ead430fbcc728687, type: 2}
+      Operator: 1
+    - ExpectedResult: 0
+      Condition: {fileID: 11400000, guid: 9c4a0f8b97247c643aef1b1284f21ebc, type: 2}
+      Operator: 1
+    - ExpectedResult: 0
+      Condition: {fileID: 11400000, guid: 620f4efd93744084a8ac9ba272f093dc, type: 2}
+      Operator: 1
+    - ExpectedResult: 0
+      Condition: {fileID: 11400000, guid: c7258bdb2558a214f916c8b5b3c0fa1f, type: 2}
+      Operator: 0
+  - FromState: {fileID: 11400000, guid: 390bddf5271c3024b8a375a0a62d0990, type: 2}
+    ToState: {fileID: 11400000, guid: c57ed1dc57a890943b2648ca8a581075, type: 2}
+    Conditions:
+    - ExpectedResult: 1
+      Condition: {fileID: 11400000, guid: c7258bdb2558a214f916c8b5b3c0fa1f, type: 2}
+      Operator: 0
+  - FromState: {fileID: 11400000, guid: 856d49f6d9474464cb77059057f969a5, type: 2}
+    ToState: {fileID: 11400000, guid: 027d32476800b3543b2f5446a59054c8, type: 2}
+    Conditions:
+    - ExpectedResult: 0
+      Condition: {fileID: 11400000, guid: a79b812272ab8314aa305b39f9a2740a, type: 2}
       Operator: 0

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/Idle.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/Idle.asset
@@ -17,3 +17,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: bcf4edc006209d54da9cd4c18329bb43, type: 2}
   - {fileID: 11400000, guid: bd85c54d16eb60c4c99504f1679af851, type: 2}
   - {fileID: 11400000, guid: 47d9da417e68970419335f80f4395239, type: 2}
+  - {fileID: 11400000, guid: 49dad5a4b1fa43844ab26a848b9bcc18, type: 2}

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/Idle.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/Idle.asset
@@ -17,4 +17,3 @@ MonoBehaviour:
   - {fileID: 11400000, guid: bcf4edc006209d54da9cd4c18329bb43, type: 2}
   - {fileID: 11400000, guid: bd85c54d16eb60c4c99504f1679af851, type: 2}
   - {fileID: 11400000, guid: 47d9da417e68970419335f80f4395239, type: 2}
-  - {fileID: 11400000, guid: 49dad5a4b1fa43844ab26a848b9bcc18, type: 2}

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/JumpDescending.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/JumpDescending.asset
@@ -13,8 +13,4 @@ MonoBehaviour:
   m_Name: JumpDescending
   m_EditorClassIdentifier: 
   _actions:
-  - {fileID: 11400000, guid: b099300f484e1344487cc666f75825cc, type: 2}
   - {fileID: 11400000, guid: 5d442cfcb78da8b418d6ae3e93e5748e, type: 2}
-  - {fileID: 11400000, guid: 47d9da417e68970419335f80f4395239, type: 2}
-  - {fileID: 11400000, guid: 096d532f9a47f3145892efa1c4322e72, type: 2}
-  - {fileID: 11400000, guid: 99b804881a9d5744fb4784c30000c0b5, type: 2}

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/JumpDescending.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/JumpDescending.asset
@@ -14,3 +14,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _actions:
   - {fileID: 11400000, guid: 5d442cfcb78da8b418d6ae3e93e5748e, type: 2}
+  - {fileID: 11400000, guid: 47d9da417e68970419335f80f4395239, type: 2}

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/Landing.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/Landing.asset
@@ -10,6 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 35432205b9a6a374bbbfe6b7cac92179, type: 3}
-  m_Name: PreventAction_Descending
+  m_Name: Landing
   m_EditorClassIdentifier: 
-  _actions: []
+  _actions:
+  - {fileID: 11400000, guid: 49dad5a4b1fa43844ab26a848b9bcc18, type: 2}

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/Landing.asset.meta
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/Landing.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 390bddf5271c3024b8a375a0a62d0990
+guid: 622df1fde8c210a439bbb2fcb2dbc4d2
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/PreventAction_Attack.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/PreventAction_Attack.asset
@@ -10,11 +10,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 35432205b9a6a374bbbfe6b7cac92179, type: 3}
-  m_Name: JumpDescending
+  m_Name: PreventAction_Attack
   m_EditorClassIdentifier: 
   _actions:
-  - {fileID: 11400000, guid: b099300f484e1344487cc666f75825cc, type: 2}
-  - {fileID: 11400000, guid: 5d442cfcb78da8b418d6ae3e93e5748e, type: 2}
-  - {fileID: 11400000, guid: 47d9da417e68970419335f80f4395239, type: 2}
-  - {fileID: 11400000, guid: 096d532f9a47f3145892efa1c4322e72, type: 2}
-  - {fileID: 11400000, guid: 99b804881a9d5744fb4784c30000c0b5, type: 2}
+  - {fileID: 11400000, guid: 5cb6e4529b034ff4dbc7a7aa863ce969, type: 2}
+  - {fileID: 11400000, guid: 0b38abb4ef196264188f86997cf47770, type: 2}

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/PreventAction_Attack.asset.meta
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/PreventAction_Attack.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 856d49f6d9474464cb77059057f969a5
+guid: bda8bfafdf35e3e4092bb96279d4894c
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/PreventAction_Descending.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/PreventAction_Descending.asset
@@ -10,6 +10,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 35432205b9a6a374bbbfe6b7cac92179, type: 3}
-  m_Name: Attack
+  m_Name: PreventAction_Descending
   m_EditorClassIdentifier: 
   _actions: []

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/PreventAction_Descending.asset.meta
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/PreventAction_Descending.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 856d49f6d9474464cb77059057f969a5
+guid: 390bddf5271c3024b8a375a0a62d0990
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/PreventAction_JumpDescending.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/PreventAction_JumpDescending.asset
@@ -10,14 +10,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 35432205b9a6a374bbbfe6b7cac92179, type: 3}
-  m_Name: Walking
+  m_Name: PreventAction_JumpDescending
   m_EditorClassIdentifier: 
   _actions:
-  - {fileID: 11400000, guid: 201885673bd707f4c9b5f3a92eca204f, type: 2}
-  - {fileID: 11400000, guid: 6a9da1e686e8c3142bcbcc7ccb5bd5ac, type: 2}
-  - {fileID: 11400000, guid: bd85c54d16eb60c4c99504f1679af851, type: 2}
+  - {fileID: 11400000, guid: 5d442cfcb78da8b418d6ae3e93e5748e, type: 2}
+  - {fileID: 11400000, guid: b099300f484e1344487cc666f75825cc, type: 2}
   - {fileID: 11400000, guid: 47d9da417e68970419335f80f4395239, type: 2}
   - {fileID: 11400000, guid: 096d532f9a47f3145892efa1c4322e72, type: 2}
-  - {fileID: 11400000, guid: fa0ce5b895dcf17499819f0d6f2dce96, type: 2}
-  - {fileID: 11400000, guid: 5aac41c53e47f1040a52303b2000ceb5, type: 2}
-  - {fileID: 11400000, guid: 74800142628360a42bb516b1e5c630e1, type: 2}
+  - {fileID: 11400000, guid: 99b804881a9d5744fb4784c30000c0b5, type: 2}

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/PreventAction_JumpDescending.asset.meta
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/PreventAction_JumpDescending.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 390bddf5271c3024b8a375a0a62d0990
+guid: c57ed1dc57a890943b2648ca8a581075
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/PreventAction_Talk.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/PreventAction_Talk.asset
@@ -10,6 +10,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 35432205b9a6a374bbbfe6b7cac92179, type: 3}
-  m_Name: new Talk
+  m_Name: Talk
   m_EditorClassIdentifier: 
-  _actions: []
+  _actions:
+  - {fileID: 11400000, guid: 7ad91f04f328d9d42a677833fa39748d, type: 2}
+  - {fileID: 11400000, guid: 1cbeab9d369d57546a33afac8ca7810f, type: 2}

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/PreventAction_Talk.asset.meta
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/PreventAction_Talk.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 14e5b8d9014246c4dbf49b1bea050396
+guid: ff92a93d8a8694247b507d811c88e402
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/Walking.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/Walking.asset
@@ -21,3 +21,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: fa0ce5b895dcf17499819f0d6f2dce96, type: 2}
   - {fileID: 11400000, guid: 5aac41c53e47f1040a52303b2000ceb5, type: 2}
   - {fileID: 11400000, guid: 74800142628360a42bb516b1e5c630e1, type: 2}
+  - {fileID: 11400000, guid: 49dad5a4b1fa43844ab26a848b9bcc18, type: 2}


### PR DESCRIPTION
Fix Input for jump and attack 

Issue : https://github.com/UnityTechnologies/open-project-1/issues/297
I added an explanation in the issue.
 
Card : https://open.codecks.io/unity-open-project-1/decks/13-bugs/card/18o-input-is-cached-when-not-immediately-consumed-by-a-state

**There is a bug in my solution for Attack
For fix it in the Transition from PreventAction_Attack to Attack** 
![image](https://user-images.githubusercontent.com/27300700/106378305-ec49a300-63a3-11eb-9576-93a4f9fbc26e.png)
![image](https://user-images.githubusercontent.com/27300700/106382373-79e6bc00-63bf-11eb-92e2-bf835c12ebf1.png)



**There is another error for the  jump descending, I moved the PlayLandParticle Action
because I misinterpreted the Actions of states.**
New solution :
![image](https://user-images.githubusercontent.com/27300700/106378951-d4c0e900-63a8-11eb-80b2-e70f9a1cd492.png)

I have a new version pending which normally fix the bug.
I'm not comfortable with github so I don't know how to do the new PR or if this PR must be validated before to be able to make the new one

An idea for talk:
![image](https://user-images.githubusercontent.com/27300700/106379992-bca09800-63af-11eb-8164-e66e7b6e1948.png)

Demo attack and pick up :
Like you can see, there is no pick up animation when we attack and pickup
![UOP1_Project - InteractionExample - PC, Mac   Linux Standalone - Unity 2019 4 18f1 Personal  PREVIEW PACKAGES IN USE  _DX11_ 2021-01-31 11-14-52_Trim](https://user-images.githubusercontent.com/27300700/106381000-35a2ee00-63b6-11eb-8a4d-b0690832a2c7.gif)
