### PR TITLE
Allowed SM hot reloading and removed "CacheResult" from ConditionSOs

### DIFF
--- a/UOP1_Project/Assets/Scripts/StateMachine/Core/StateCondition.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Core/StateCondition.cs
@@ -27,9 +27,6 @@ namespace UOP1.StateMachine
 		/// </summary>
 		internal bool GetStatement()
 		{
-			if (!_originSO.cacheResult)
-				return Statement();
-
 			if (!_isCached)
 			{
 				_isCached = true;

--- a/UOP1_Project/Assets/Scripts/StateMachine/Core/StateMachine.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/Core/StateMachine.cs
@@ -26,6 +26,24 @@ namespace UOP1.StateMachine
 #endif
 		}
 
+#if UNITY_EDITOR
+		private void OnEnable()
+		{
+			UnityEditor.AssemblyReloadEvents.afterAssemblyReload += OnAfterAssemblyReload;
+		}
+
+		private void OnAfterAssemblyReload()
+		{
+			_currentState = _transitionTableSO.GetInitialState(this);
+			_debugger.Awake(this);
+		}
+
+		private void OnDisable()
+		{
+			UnityEditor.AssemblyReloadEvents.afterAssemblyReload -= OnAfterAssemblyReload;
+		}
+#endif
+
 		private void Start()
 		{
 			_currentState.OnStateEnter();

--- a/UOP1_Project/Assets/Scripts/StateMachine/ScriptableObjects/StateConditionSO.cs
+++ b/UOP1_Project/Assets/Scripts/StateMachine/ScriptableObjects/StateConditionSO.cs
@@ -5,10 +5,6 @@ namespace UOP1.StateMachine.ScriptableObjects
 {
 	public abstract class StateConditionSO : ScriptableObject
 	{
-		[SerializeField]
-		[Tooltip("The condition will only be evaluated once each frame, and cached for subsequent uses.\r\n\r\nThe caching is unique to each instance of the State Machine and of the Scriptable Object (i.e. Instances of the State Machine or Condition don't share results if they belong to different GameObjects).")]
-		internal bool cacheResult = true;
-
 		/// <summary>
 		/// Will create a new custom <see cref="Condition"/> or use an existing one inside <paramref name="createdInstances"/>.
 		/// </summary>


### PR DESCRIPTION
[SM Thread](https://forum.unity.com/threads/state-machine.979371/)

### SM Hot reloading
Finally, you can now enable the option `Recompile And Continue Playing` without having the PigCheff and every Critter break.

### Removed the "Cache Result" option in StateConditionSOs
The option was causing more confusion than anything and wasn't being used at all. Every condition had it on since it's the default, so I've left the feature active at all times while removing the toggle as discussed [here](https://forum.unity.com/threads/input-cached-when-not-immediately-consumed-by-a-state.1022698/#post-6786170).