### PR TITLE
fix/DialogueManager throw null reference exception if OpenDialogueUIEvent is not initialized.

### DIFF
--- a/UOP1_Project/Assets/Scripts/Dialogues/DialogueManager.cs
+++ b/UOP1_Project/Assets/Scripts/Dialogues/DialogueManager.cs
@@ -30,7 +30,7 @@ public class DialogueManager : MonoBehaviour
 		//TODO: Interface with a UIManager to allow displayal of the line of dialogue in the UI
 		//Debug.Log("A line of dialogue has been spoken: \"" + dialogueLine.Sentence + "\" by " + dialogueLine.Actor.ActorName);
 		if (dialogueLineEvent != null)
-			dialogueLineEvent.OnEventRaised(dialogueLine);
+			dialogueLineEvent.RaiseEvent(dialogueLine);
 
 	}
 }

--- a/UOP1_Project/Assets/Scripts/Inventory/UIInventoryManager.cs
+++ b/UOP1_Project/Assets/Scripts/Inventory/UIInventoryManager.cs
@@ -327,7 +327,7 @@ public class UIInventoryManager : MonoBehaviour
 	{
 		Debug.Log("USE ITEM " + itemToUse.name);
 
-		UseItemEvent.OnEventRaised(itemToUse);
+		UseItemEvent.RaiseEvent(itemToUse);
 		//update inventory
 		FillInventory();
 	}
@@ -336,14 +336,14 @@ public class UIInventoryManager : MonoBehaviour
 	void EquipItem(Item itemToUse)
 	{
 		Debug.Log("Equip ITEM " + itemToUse.name);
-		EquipItemEvent.OnEventRaised(itemToUse);
+		EquipItemEvent.RaiseEvent(itemToUse);
 	}
 
 	void CookRecipe(Item recipeToCook)
 	{
 
 		//get item
-		CookRecipeEvent.OnEventRaised(recipeToCook);
+		CookRecipeEvent.RaiseEvent(recipeToCook);
 
 		//update inspector
 		InspectItem(recipeToCook);


### PR DESCRIPTION
Just a minor bug. 
But of course, safety  :D

Issue: https://github.com/UnityTechnologies/open-project-1/issues/343

I solved it by: Invoking the the channel's method ( RaiseEvent() ) rather than the event it self (OnEventRaised) in DialogueManager.cs

EDIT:
I also do the same thing in UIEventoryManager.cs

-----------------

To not make this issue happen again, do anyone know how to protect OnEventRaised to not be invoked outside of the EventChannels script but initialize-able by other scripts? 