### PR TITLE
fix for camera Lerps into place

### DIFF
--- a/UOP1_Project/Assets/Scripts/CameraManager.cs
+++ b/UOP1_Project/Assets/Scripts/CameraManager.cs
@@ -11,11 +11,7 @@ public class CameraManager : MonoBehaviour
 	private bool _isRMBPressed;
 
 	[SerializeField, Range(.5f, 3f)]
-	private float _speedMultiplier = 1f; //TODO: make this modifiable in the game settings
-
-	//this is the distance from player the camera will warp to when a new scene is loaded. this can be set individually on each scene, zero is the most consistent
-	[SerializeField,Tooltip("the distance from player the camera will warp to when a new scene is loaded")]
-	private float _SpawnDistanceFromPlayer = 0f; 											
+	private float _speedMultiplier = 1f; //TODO: make this modifiable in the game settings											
 	[SerializeField] private TransformAnchor _cameraTransformAnchor = default;
 
 	[Header("Listening on channels")]
@@ -29,9 +25,7 @@ public class CameraManager : MonoBehaviour
 	{
 		freeLookVCam.Follow = target;
 		freeLookVCam.LookAt = target;
-		//warp the camera to target without lerping to avoid long lerps
-		Vector3 positionDelta = (target.position-freeLookVCam.transform.position) - (target.position-freeLookVCam.transform.position).normalized*_SpawnDistanceFromPlayer;
-		freeLookVCam.OnTargetObjectWarped(target,positionDelta);
+		freeLookVCam.OnTargetObjectWarped(target,target.position-freeLookVCam.transform.position);
 	}
 
 	private void OnEnable()

--- a/UOP1_Project/Assets/Scripts/CameraManager.cs
+++ b/UOP1_Project/Assets/Scripts/CameraManager.cs
@@ -25,6 +25,7 @@ public class CameraManager : MonoBehaviour
 	{
 		freeLookVCam.Follow = target;
 		freeLookVCam.LookAt = target;
+		freeLookVCam.OnTargetObjectWarped(target,target.position-freeLookVCam.transform.position);
 	}
 
 	private void OnEnable()
@@ -93,6 +94,7 @@ public class CameraManager : MonoBehaviour
 
 	private void OnFrameObjectEvent(Transform value)
 	{
+		Debug.Log("distance of player from camera:" + Vector3.Distance(freeLookVCam.transform.position,value.position));
 		SetupProtagonistVirtualCamera(value);
 	}
 }

--- a/UOP1_Project/Assets/Scripts/CameraManager.cs
+++ b/UOP1_Project/Assets/Scripts/CameraManager.cs
@@ -12,6 +12,10 @@ public class CameraManager : MonoBehaviour
 
 	[SerializeField, Range(.5f, 3f)]
 	private float _speedMultiplier = 1f; //TODO: make this modifiable in the game settings
+
+	//this is the distance from player the camera will warp to when a new scene is loaded. this can be set individually on each scene, zero is the most consistent
+	[SerializeField,Tooltip("the distance from player the camera will warp to when a new scene is loaded")]
+	private float _SpawnDistanceFromPlayer = 0f; 											
 	[SerializeField] private TransformAnchor _cameraTransformAnchor = default;
 
 	[Header("Listening on channels")]
@@ -25,7 +29,9 @@ public class CameraManager : MonoBehaviour
 	{
 		freeLookVCam.Follow = target;
 		freeLookVCam.LookAt = target;
-		freeLookVCam.OnTargetObjectWarped(target,target.position-freeLookVCam.transform.position);
+		//warp the camera to target without lerping to avoid long lerps
+		Vector3 positionDelta = (target.position-freeLookVCam.transform.position) - (target.position-freeLookVCam.transform.position).normalized*_SpawnDistanceFromPlayer;
+		freeLookVCam.OnTargetObjectWarped(target,positionDelta);
 	}
 
 	private void OnEnable()
@@ -94,7 +100,6 @@ public class CameraManager : MonoBehaviour
 
 	private void OnFrameObjectEvent(Transform value)
 	{
-		Debug.Log("distance of player from camera:" + Vector3.Distance(freeLookVCam.transform.position,value.position));
 		SetupProtagonistVirtualCamera(value);
 	}
 }


### PR DESCRIPTION

fix for issue: #340 
link to forum thread: https://forum.unity.com/threads/camera-lerps-into-place-at-the-beginning-of-a-scene.1052282/

**How did you resolve this issue?** 
 After a new scene is loaded, the Camera Manager in the scene manager calls SetupProtagonistVirtualCamera() to set the target of the free look vcam. After setting the target, I have used OnTargetWarped() to warp the camera close the the player without lerping. I have also added a field in camera manager called _SpawnDistanceFromPlayer to set how far from the player the camera will warp. I found the most consistent results in terms of camera movement for a value of zero.

**How can it be verified that the issue has actually been resolved?**  
you may follow the steps to reproduce the bug mentioned in the issue, the vcam will now only move a small amount on location change