### PR TITLE
To avoid developer to call "OnEventRaised" action instead of calling …

### DIFF
--- a/UOP1_Project/Assets/Scripts/Audio/AudioManager.cs
+++ b/UOP1_Project/Assets/Scripts/Audio/AudioManager.cs
@@ -83,16 +83,16 @@ public class AudioManager : MonoBehaviour
 
 	private void RegisterChannel(AudioCueEventChannelSO audioCueEventChannel)
 	{
-		audioCueEventChannel.OnAudioCuePlayRequested += PlayAudioCue;
-		audioCueEventChannel.OnAudioCueStopRequested += StopAudioCue;
-		audioCueEventChannel.OnAudioCueFinishRequested += FinishAudioCue;
+		audioCueEventChannel.RegisterAudioCuePlayEvent(PlayAudioCue);
+		audioCueEventChannel.RegisteAudioCueStopEvent(StopAudioCue);
+		audioCueEventChannel.RegisteAudioCueFinishEvent(FinishAudioCue);
 	}
 
 	private void UnregisterChannel(AudioCueEventChannelSO audioCueEventChannel)
 	{
-		audioCueEventChannel.OnAudioCuePlayRequested += PlayAudioCue;
-		audioCueEventChannel.OnAudioCueStopRequested += StopAudioCue;
-		audioCueEventChannel.OnAudioCueFinishRequested += FinishAudioCue;
+		audioCueEventChannel.UnregisterAudioCuePlayEvent(PlayAudioCue);
+		audioCueEventChannel.UnregisteAudioCueStopEvent(StopAudioCue);
+		audioCueEventChannel.UnregisteAudioCueFinishEvent(FinishAudioCue);
 	}
 
 	// Both MixerValueNormalized and NormalizedToMixerValue functions are used for easier transformations

--- a/UOP1_Project/Assets/Scripts/CameraManager.cs
+++ b/UOP1_Project/Assets/Scripts/CameraManager.cs
@@ -35,7 +35,7 @@ public class CameraManager : MonoBehaviour
 		inputReader.disableMouseControlCameraEvent += OnDisableMouseControlCamera;
 
 		if (_frameObjectChannel != null)
-			_frameObjectChannel.OnEventRaised += OnFrameObjectEvent;
+			_frameObjectChannel.RegisterEvent(OnFrameObjectEvent);
 
 		_cameraTransformAnchor.Transform = mainCamera.transform;
 	}
@@ -47,7 +47,7 @@ public class CameraManager : MonoBehaviour
 		inputReader.disableMouseControlCameraEvent -= OnDisableMouseControlCamera;
 
 		if (_frameObjectChannel != null)
-			_frameObjectChannel.OnEventRaised -= OnFrameObjectEvent;
+			_frameObjectChannel.UnregisterEvent(OnFrameObjectEvent);
 	}
 
 	private void OnEnableMouseControlCamera()

--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Conditions/HasReceivedEventSO.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Conditions/HasReceivedEventSO.cs
@@ -17,7 +17,7 @@ public class HasReceivedEventCondition : Condition
 	public override void Awake(StateMachine stateMachine)
 	{
 		_eventTriggered = false;
-		_originSO.voidEvent.OnEventRaised += EventReceived;
+		_originSO.voidEvent.RegisterEvent(EventReceived);
 	}
 
 	protected override bool Statement()

--- a/UOP1_Project/Assets/Scripts/Dialogues/DialogueManager.cs
+++ b/UOP1_Project/Assets/Scripts/Dialogues/DialogueManager.cs
@@ -30,7 +30,7 @@ public class DialogueManager : MonoBehaviour
 		//TODO: Interface with a UIManager to allow displayal of the line of dialogue in the UI
 		//Debug.Log("A line of dialogue has been spoken: \"" + dialogueLine.Sentence + "\" by " + dialogueLine.Actor.ActorName);
 		if (dialogueLineEvent != null)
-			dialogueLineEvent.OnEventRaised(dialogueLine);
+			dialogueLineEvent.RaiseEvent(dialogueLine);
 
 	}
 }

--- a/UOP1_Project/Assets/Scripts/Events/IntEventListener.cs
+++ b/UOP1_Project/Assets/Scripts/Events/IntEventListener.cs
@@ -22,13 +22,13 @@ public class IntEventListener : MonoBehaviour
 	private void OnEnable()
 	{
 		if (_channel != null)
-			_channel.OnEventRaised += Respond;
+			_channel.RegisterEvent(Respond);
 	}
 
 	private void OnDisable()
 	{
 		if (_channel != null)
-			_channel.OnEventRaised -= Respond;
+			_channel.UnregisterEvent(Respond);
 	}
 
 	private void Respond(int value)

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/AudioCueEventChannelSO.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/AudioCueEventChannelSO.cs
@@ -9,9 +9,9 @@ using System.Collections.Generic;
 [CreateAssetMenu(menuName = "Events/AudioCue Event Channel")]
 public class AudioCueEventChannelSO : EventChannelBaseSO
 {
-	public AudioCuePlayAction OnAudioCuePlayRequested;
-	public AudioCueStopAction OnAudioCueStopRequested;
-	public AudioCueFinishAction OnAudioCueFinishRequested;
+	private AudioCuePlayAction OnAudioCuePlayRequested;
+	private AudioCueStopAction OnAudioCueStopRequested;
+	private AudioCueFinishAction OnAudioCueFinishRequested;
 
 	public AudioCueKey RaisePlayEvent(AudioCueSO audioCue, AudioConfigurationSO audioConfiguration, Vector3 positionInSpace)
 	{
@@ -66,6 +66,36 @@ public class AudioCueEventChannelSO : EventChannelBaseSO
 
 		return requestSucceed;
 	}
+
+	public void RegisterAudioCuePlayEvent(AudioCuePlayAction action) {
+		OnAudioCuePlayRequested += action;
+	}
+
+	public void RegisteAudioCueStopEvent(AudioCueStopAction action)
+	{
+		OnAudioCueStopRequested += action;
+	}
+
+	public void RegisteAudioCueFinishEvent(AudioCueFinishAction action)
+	{
+		OnAudioCueFinishRequested += action;
+	}
+
+	public void UnregisterAudioCuePlayEvent(AudioCuePlayAction action)
+	{
+		OnAudioCuePlayRequested -= action;
+	}
+
+	public void UnregisteAudioCueStopEvent(AudioCueStopAction action)
+	{
+		OnAudioCueStopRequested -= action;
+	}
+
+	public void UnregisteAudioCueFinishEvent(AudioCueFinishAction action)
+	{
+		OnAudioCueFinishRequested -= action;
+	}
+
 }
 
 public delegate AudioCueKey AudioCuePlayAction(AudioCueSO audioCue, AudioConfigurationSO audioConfiguration, Vector3 positionInSpace);

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/BoolEventChannelSO.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/BoolEventChannelSO.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine.Events;
 using UnityEngine;
+using System;
 
 /// <summary>
 /// This class is used for Events that have a bool argument.
@@ -7,12 +8,6 @@ using UnityEngine;
 /// </summary>
 
 [CreateAssetMenu(menuName = "Events/Bool Event Channel")]
-public class BoolEventChannelSO : ScriptableObject
+public class BoolEventChannelSO : EventChannelGenericSO <Boolean>
 {
-	public UnityAction<bool> OnEventRaised;
-	public void RaiseEvent(bool value)
-	{
-		if (OnEventRaised != null)
-			OnEventRaised.Invoke(value);
-	}
 }

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/DialogueEventChannelSo.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/DialogueEventChannelSo.cs
@@ -7,13 +7,8 @@ using UnityEngine;
 /// </summary>
 
 [CreateAssetMenu(menuName = "Events/Dialogue Event Channel")]
-public class DialogueEventChannelSO : ScriptableObject
+public class DialogueEventChannelSO : EventChannelGenericSO <ActorSO>
 {
-	public UnityAction<ActorSO> OnEventRaised;
-	public void RaiseEvent(ActorSO actor)
-	{
-		if (OnEventRaised != null)
-			OnEventRaised.Invoke(actor);
-	}
+	
 }
 

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/EventChannelGenericSO.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/EventChannelGenericSO.cs
@@ -1,0 +1,23 @@
+﻿using UnityEngine;
+using UnityEngine.Events;
+
+public abstract class EventChannelGenericSO <T> : EventChannelBaseSO
+{
+	protected UnityAction<T> action;
+
+	public void RegisterEvent(UnityAction<T> action) {
+		this.action += action;
+	}
+
+	public void UnregisterEvent(UnityAction<T> action)
+	{
+		this.action -= action;
+	}
+
+	public void RaiseEvent(T value)
+	{
+		if (action != null)
+			action.Invoke(value);
+	}
+
+}

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/GameObjectEventChannelSO.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/GameObjectEventChannelSO.cs
@@ -7,12 +7,7 @@ using UnityEngine;
 /// </summary>
 
 [CreateAssetMenu(menuName = "Events/GameObject Event Channel")]
-public class GameObjectEventChannelSO : ScriptableObject
+public class GameObjectEventChannelSO : EventChannelGenericSO <GameObject>
 {
-	public UnityAction<GameObject> OnEventRaised;
-	public void RaiseEvent(GameObject value)
-	{
-		if (OnEventRaised != null)
-			OnEventRaised.Invoke(value);
-	}
+	
 }

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/IntEventChannelSO.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/IntEventChannelSO.cs
@@ -7,11 +7,6 @@ using UnityEngine;
 /// </summary>
 
 [CreateAssetMenu(menuName = "Events/Int Event Channel")]
-public class IntEventChannelSO : EventChannelBaseSO
+public class IntEventChannelSO : EventChannelGenericSO <int>
 {
-	public UnityAction<int> OnEventRaised;
-	public void RaiseEvent(int value)
-	{
-		OnEventRaised.Invoke(value);
-	}
 }

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/InteractionUIEventChannelSO.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/InteractionUIEventChannelSO.cs
@@ -9,12 +9,21 @@ using UnityEngine;
 [CreateAssetMenu(menuName = "Events/Toogle Interaction UI Event Channel")]
 public class InteractionUIEventChannelSO : ScriptableObject
 {
-	public UnityAction<bool, InteractionType> OnEventRaised;
+	private UnityAction<bool, InteractionType> OnEventRaised;
 	public void RaiseEvent(bool state, InteractionType interactionType)
 	{
 		if (OnEventRaised != null)
 			OnEventRaised.Invoke(state, interactionType);
 	}
 
+	public void RegisterEvent(UnityAction<bool, InteractionType> action) 
+	{
+		OnEventRaised += action;
+	}
+
+	public void UnregisterEvent(UnityAction<bool, InteractionType> action)
+	{
+		OnEventRaised -= action;
+	}
 }
 

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/ItemEventChannelSo.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/ItemEventChannelSo.cs
@@ -7,13 +7,8 @@ using UnityEngine;
 /// </summary>
 
 [CreateAssetMenu(menuName = "Events/UI/Item Event Channel")]
-public class ItemEventChannelSO : ScriptableObject
+public class ItemEventChannelSO  : EventChannelGenericSO <Item>
 {
-	public UnityAction<Item> OnEventRaised;
-	public void RaiseEvent(Item item)
-	{
-		if (OnEventRaised != null)
-			OnEventRaised.Invoke(item);
-	}
+	
 }
 

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/TransformEventChannelSO.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/TransformEventChannelSO.cs
@@ -7,13 +7,7 @@ using UnityEngine;
 /// </summary>
 
 [CreateAssetMenu(menuName = "Events/Transform Event Channel")]
-public class TransformEventChannelSO : EventChannelBaseSO
+public class TransformEventChannelSO  : EventChannelGenericSO <Transform>
 {
-	public UnityAction<Transform> OnEventRaised;
-
-	public void RaiseEvent(Transform value)
-	{
-		if (OnEventRaised != null)
-			OnEventRaised.Invoke(value);
-	}
+	
 }

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/UI/DialogueLineChannelSO.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/UI/DialogueLineChannelSO.cs
@@ -4,12 +4,6 @@ using UnityEngine;
 using UnityEngine.Events;
 
 [CreateAssetMenu(menuName = "Events/UI/Dialogue line Channel")]
-public class DialogueLineChannelSO : ScriptableObject
+public class DialogueLineChannelSO : EventChannelGenericSO <DialogueLineSO>
 {
-	public UnityAction<DialogueLineSO> OnEventRaised;
-	public void RaiseEvent(DialogueLineSO line)
-	{
-		if (OnEventRaised != null)
-			OnEventRaised.Invoke(line);
-	}
 }

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/UI/FadeChannelSO.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/UI/FadeChannelSO.cs
@@ -6,7 +6,7 @@ using UnityEngine.Events;
 [CreateAssetMenu(menuName = "Events/UI/Fade Channel")]
 public class FadeChannelSO : ScriptableObject
 {
-	public UnityAction<bool, float, Color> OnEventRaised;
+	private UnityAction<bool, float, Color> OnEventRaised;
 	/// <summary>
 	/// Generic fade function. Communicates with <seealso cref="FadeManager.cs"/>.
 	/// </summary>
@@ -40,4 +40,14 @@ public class FadeChannelSO : ScriptableObject
 	{
 		Fade(false, duration, color);
 	}
+
+	public void RegisterFadeEvent(UnityAction<bool, float, Color> action) {
+		OnEventRaised += action;
+	}
+
+	public void UnregisterFadeEvent(UnityAction<bool, float, Color> action)
+	{
+		OnEventRaised -= action;
+	}
+
 }

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/UI/TabEventChannelSo.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/UI/TabEventChannelSo.cs
@@ -4,12 +4,7 @@ using UnityEngine;
 using UnityEngine.Events;
 
 [CreateAssetMenu(menuName = "Events/UI/Inventory Tab Event Channel")]
-public class TabEventChannelSo : ScriptableObject
+public class TabEventChannelSo : EventChannelGenericSO<InventoryTabType>
 {
-	public UnityAction<InventoryTabType> OnEventRaised;
-	public void RaiseEvent(InventoryTabType item)
-	{
-		if (OnEventRaised != null)
-			OnEventRaised.Invoke(item);
-	}
+
 }

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/VoidEventChannelSO.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/VoidEventChannelSO.cs
@@ -8,13 +8,25 @@ using UnityEngine.Events;
 [CreateAssetMenu(menuName = "Events/Void Event Channel")]
 public class VoidEventChannelSO : EventChannelBaseSO
 {
-	public UnityAction OnEventRaised;
+	private UnityAction OnEventRaised;
 
 	public void RaiseEvent()
 	{
 		if (OnEventRaised != null)
 			OnEventRaised.Invoke();
 	}
+
+	public void RegisterEvent(UnityAction action) {
+		OnEventRaised += action;
+	}
+
+	public void UnregisterEvent(UnityAction action)
+	{
+		OnEventRaised -= action;
+	}
+
+
+
 }
 
 

--- a/UOP1_Project/Assets/Scripts/Events/VoidEventListener.cs
+++ b/UOP1_Project/Assets/Scripts/Events/VoidEventListener.cs
@@ -13,13 +13,13 @@ public class VoidEventListener : MonoBehaviour
 	private void OnEnable()
 	{
 		if (_channel != null)
-			_channel.OnEventRaised += Respond;
+			_channel.RegisterEvent(Respond);
 	}
 
 	private void OnDisable()
 	{
 		if (_channel != null)
-			_channel.OnEventRaised -= Respond;
+			_channel.UnregisterEvent(Respond);
 	}
 
 	private void Respond()

--- a/UOP1_Project/Assets/Scripts/Interaction/InteractionManager.cs
+++ b/UOP1_Project/Assets/Scripts/Interaction/InteractionManager.cs
@@ -23,13 +23,13 @@ public class InteractionManager : MonoBehaviour
 	private void OnEnable()
 	{
 		_inputReader.interactEvent += OnInteractionButtonPress;
-		_onInteractionEnded.OnEventRaised += OnInteractionEnd;
+		_onInteractionEnded.RegisterEvent(OnInteractionEnd);
 	}
 
 	private void OnDisable()
 	{
 		_inputReader.interactEvent -= OnInteractionButtonPress;
-		_onInteractionEnded.OnEventRaised -= OnInteractionEnd;
+		_onInteractionEnded.UnregisterEvent(OnInteractionEnd);
 	}
 
 	// Called mid-way through the AnimationClip of collecting

--- a/UOP1_Project/Assets/Scripts/Inventory/InventoryManager.cs
+++ b/UOP1_Project/Assets/Scripts/Inventory/InventoryManager.cs
@@ -26,23 +26,23 @@ public class InventoryManager : MonoBehaviour
 		//Check if the event exists to avoid errors
 		if (CookRecipeEvent != null)
 		{
-			CookRecipeEvent.OnEventRaised += CookRecipeEventRaised;
+			CookRecipeEvent.RegisterEvent(CookRecipeEventRaised);
 		}
 		if (UseItemEvent != null)
 		{
-			UseItemEvent.OnEventRaised += UseItemEventRaised;
+			UseItemEvent.RegisterEvent(UseItemEventRaised);
 		}
 		if (EquipItemEvent != null)
 		{
-			EquipItemEvent.OnEventRaised += EquipItemEventRaised;
+			EquipItemEvent.RegisterEvent(EquipItemEventRaised);
 		}
 		if (AddItemEvent != null)
 		{
-			AddItemEvent.OnEventRaised += AddItem;
+			AddItemEvent.RegisterEvent(AddItem);
 		}
 		if (RemoveItemEvent != null)
 		{
-			RemoveItemEvent.OnEventRaised += RemoveItem;
+			RemoveItemEvent.RegisterEvent(RemoveItem);
 		}
 	}
 
@@ -50,23 +50,23 @@ public class InventoryManager : MonoBehaviour
 	{
 		if (CookRecipeEvent != null)
 		{
-			CookRecipeEvent.OnEventRaised -= CookRecipeEventRaised;
+			CookRecipeEvent.UnregisterEvent(CookRecipeEventRaised);
 		}
 		if (UseItemEvent != null)
 		{
-			UseItemEvent.OnEventRaised -= UseItemEventRaised;
+			UseItemEvent.UnregisterEvent(UseItemEventRaised);
 		}
 		if (EquipItemEvent != null)
 		{
-			EquipItemEvent.OnEventRaised -= EquipItemEventRaised;
+			EquipItemEvent.UnregisterEvent(EquipItemEventRaised);
 		}
 		if (AddItemEvent != null)
 		{
-			AddItemEvent.OnEventRaised -= AddItem;
+			AddItemEvent.UnregisterEvent(AddItem);
 		}
 		if (RemoveItemEvent != null)
 		{
-			RemoveItemEvent.OnEventRaised -= RemoveItem;
+			RemoveItemEvent.UnregisterEvent(RemoveItem);
 		}
 	}
 

--- a/UOP1_Project/Assets/Scripts/Inventory/UIInventoryManager.cs
+++ b/UOP1_Project/Assets/Scripts/Inventory/UIInventoryManager.cs
@@ -45,19 +45,19 @@ public class UIInventoryManager : MonoBehaviour
 		//Check if the event exists to avoid errors
 		if (ActionButtonClicked != null)
 		{
-			ActionButtonClicked.OnEventRaised += ActionButtonEventRaised;
+			ActionButtonClicked.RegisterEvent(ActionButtonEventRaised);
 		}
 		if (ChangeTabEvent != null)
 		{
-			ChangeTabEvent.OnEventRaised += ChangeTabEventRaised;
+			ChangeTabEvent.RegisterEvent(ChangeTabEventRaised);
 		}
 		if (SelectItemEvent != null)
 		{
-			SelectItemEvent.OnEventRaised += InspectItem;
+			SelectItemEvent.RegisterEvent(InspectItem);
 		}
 		if (OnInteractionEndedEvent != null)
 		{
-			OnInteractionEndedEvent.OnEventRaised += InteractionEnded;
+			OnInteractionEndedEvent.RegisterEvent(InteractionEnded);
 		}
 	}
 
@@ -65,15 +65,15 @@ public class UIInventoryManager : MonoBehaviour
 	{
 		if (ActionButtonClicked != null)
 		{
-			ActionButtonClicked.OnEventRaised -= ActionButtonEventRaised;
+			ActionButtonClicked.UnregisterEvent(ActionButtonEventRaised);
 		}
 		if (ChangeTabEvent != null)
 		{
-			ChangeTabEvent.OnEventRaised -= ChangeTabEventRaised;
+			ChangeTabEvent.UnregisterEvent(ChangeTabEventRaised);
 		}
 		if (SelectItemEvent != null)
 		{
-			SelectItemEvent.OnEventRaised -= InspectItem;
+			SelectItemEvent.UnregisterEvent(InspectItem);
 		}
 	}
 
@@ -327,7 +327,7 @@ public class UIInventoryManager : MonoBehaviour
 	{
 		Debug.Log("USE ITEM " + itemToUse.name);
 
-		UseItemEvent.OnEventRaised(itemToUse);
+		UseItemEvent.RaiseEvent(itemToUse);
 		//update inventory
 		FillInventory();
 	}
@@ -336,14 +336,14 @@ public class UIInventoryManager : MonoBehaviour
 	void EquipItem(Item itemToUse)
 	{
 		Debug.Log("Equip ITEM " + itemToUse.name);
-		EquipItemEvent.OnEventRaised(itemToUse);
+		EquipItemEvent.RaiseEvent(itemToUse);
 	}
 
 	void CookRecipe(Item recipeToCook)
 	{
 
 		//get item
-		CookRecipeEvent.OnEventRaised(recipeToCook);
+		CookRecipeEvent.RaiseEvent(recipeToCook);
 
 		//update inspector
 		InspectItem(recipeToCook);

--- a/UOP1_Project/Assets/Scripts/SceneManagement/LoadingScreenManager.cs
+++ b/UOP1_Project/Assets/Scripts/SceneManagement/LoadingScreenManager.cs
@@ -13,7 +13,7 @@ public class LoadingScreenManager : MonoBehaviour
 	{
 		if (_ToggleLoadingScreen != null)
 		{
-			_ToggleLoadingScreen.OnEventRaised += ToggleLoadingScreen;
+			_ToggleLoadingScreen.RegisterEvent(ToggleLoadingScreen);
 		}
 	}
 
@@ -21,7 +21,7 @@ public class LoadingScreenManager : MonoBehaviour
 	{
 		if (_ToggleLoadingScreen != null)
 		{
-			_ToggleLoadingScreen.OnEventRaised += ToggleLoadingScreen;
+			_ToggleLoadingScreen.UnregisterEvent(ToggleLoadingScreen);
 		}
 	}
 

--- a/UOP1_Project/Assets/Scripts/SpawnSystem.cs
+++ b/UOP1_Project/Assets/Scripts/SpawnSystem.cs
@@ -23,7 +23,7 @@ public class SpawnSystem : MonoBehaviour
 	{
 		if (_OnSceneReady != null)
 		{
-			_OnSceneReady.OnEventRaised += SpawnPlayer;
+			_OnSceneReady.RegisterEvent(SpawnPlayer);
 		}
 	}
 
@@ -31,7 +31,7 @@ public class SpawnSystem : MonoBehaviour
 	{
 		if (_OnSceneReady != null)
 		{
-			_OnSceneReady.OnEventRaised -= SpawnPlayer;
+			_OnSceneReady.UnregisterEvent(SpawnPlayer);
 		}
 	}
 

--- a/UOP1_Project/Assets/Scripts/UI/FadeManager.cs
+++ b/UOP1_Project/Assets/Scripts/UI/FadeManager.cs
@@ -12,12 +12,12 @@ public class FadeManager : MonoBehaviour
 
 	private void OnEnable()
 	{
-		_fadeChannelSO.OnEventRaised += InitiateFade;
+		_fadeChannelSO.RegisterFadeEvent(InitiateFade);
 	}
 
 	private void OnDisable()
 	{
-		_fadeChannelSO.OnEventRaised -= InitiateFade;
+		_fadeChannelSO.UnregisterFadeEvent(InitiateFade);
 	}
 
 	/// <summary>

--- a/UOP1_Project/Assets/Scripts/UI/UIManager.cs
+++ b/UOP1_Project/Assets/Scripts/UI/UIManager.cs
@@ -21,27 +21,27 @@ public class UIManager : MonoBehaviour
 		//Check if the event exists to avoid errors
 		if (OpenUIDialogueEvent != null)
 		{
-			OpenUIDialogueEvent.OnEventRaised += OpenUIDialogue;
+			OpenUIDialogueEvent.RegisterEvent(OpenUIDialogue);
 		}
 		if (CloseUIDialogueEvent != null)
 		{
-			CloseUIDialogueEvent.OnEventRaised += CloseUIDialogue;
+			CloseUIDialogueEvent.RegisterEvent(CloseUIDialogue);
 		}
 		if (OpenInventoryScreenForCookingEvent != null)
 		{
-			OpenInventoryScreenForCookingEvent.OnEventRaised += SetInventoryScreenForCooking;
+			OpenInventoryScreenForCookingEvent.RegisterEvent(SetInventoryScreenForCooking);
 		}
 		if (OpenInventoryScreenEvent != null)
 		{
-			OpenInventoryScreenEvent.OnEventRaised += SetInventoryScreen;
+			OpenInventoryScreenEvent.RegisterEvent(SetInventoryScreen);
 		}
 		if (CloseInventoryScreenEvent != null)
 		{
-			CloseInventoryScreenEvent.OnEventRaised += CloseInventoryScreen;
+			CloseInventoryScreenEvent.RegisterEvent(CloseInventoryScreen);
 		}
 		if (SetInteractionEvent != null)
 		{
-			SetInteractionEvent.OnEventRaised += SetInteractionPanel;
+			SetInteractionEvent.RegisterEvent(SetInteractionPanel);
 		}
 
 	}


### PR DESCRIPTION
To avoid developer to call "OnEventRaised" action instead of calling RaiseEvent. This causing null pointer exception.

Also created new Class EventChannelGenericSO.cs to avoid repeatable code in event systems.


**[for Generic PRs]**  
1. Avoid repeatable code in Event systems if we want to create a new channel with new parameter type.
2. Created generic BaseEventGenericSO Class and moved RaiseEvent method inside to that class to achieve point 1.


**[for Bugfix PRs]**  
DialogueManager throw null reference exception if OpenDialogueUIEvent is not initialized
How did you resolve this issue?  make OnEventRaised as private and created public method to register
How can it be verified that the issue has actually been resolved?  
