### PR TITLE
Fixed missing attack action due to missing backup animation transitions

### DIFF
--- a/UOP1_Project/Assets/Art/Characters/PigChef/Animation/PigChef.controller
+++ b/UOP1_Project/Assets/Art/Characters/PigChef/Animation/PigChef.controller
@@ -244,7 +244,7 @@ AnimatorStateMachine:
     m_Position: {x: 30, y: 300, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 5995182924539841906}
-    m_Position: {x: 450, y: 130, z: 0}
+    m_Position: {x: 460, y: 130, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 440317740882946628}
     m_Position: {x: 270, y: 490, z: 0}
@@ -586,6 +586,28 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &-524793174078838046
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -450912674566187584}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.8943662
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &-450912674566187584
 AnimatorState:
   serializedVersion: 5
@@ -600,6 +622,7 @@ AnimatorState:
   - {fileID: -4762902591384597963}
   - {fileID: -2033464475531255411}
   - {fileID: -890836485891151347}
+  - {fileID: 4371136895507014192}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -852,6 +875,56 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &4055551502023717864
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: IsAttacking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -450912674566187584}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.8943662
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &4371136895507014192
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: IsAttacking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 5995182924539841906}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.8828125
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &4910209328142922604
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -969,6 +1042,7 @@ AnimatorState:
   - {fileID: -3235251470832908421}
   - {fileID: -1610815559573086160}
   - {fileID: 5384281710731791955}
+  - {fileID: 4055551502023717864}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0


### PR DESCRIPTION
Playing with the double animation strike of the player, I am experiencing some annoying miss attack when clicking quickly on the screen.

It took me some time to figure out what was going wrong, but finally it seems to come from the animation blending between the two attacks:
![image](https://user-images.githubusercontent.com/42570903/107220621-dd519900-6a12-11eb-93e4-8fe4a272a00c.png)
If the blending moment is in the past when the attack input becomes true again, the animator will be lost and will take a long pause before transitioning to a new attack animation.
 
A solution I found to solve this issue has been to add additional transitions to the same clip but with blending at the end:
![image](https://user-images.githubusercontent.com/42570903/107223217-3242de80-6a16-11eb-98a9-77f83daca6bf.png)

![image](https://user-images.githubusercontent.com/42570903/107223255-3ec73700-6a16-11eb-80fa-9dedd4b81c9f.png)

Is it right to do that?