### PR TITLE
AudioManager UnregisterChannel fix

### DIFF
--- a/UOP1_Project/Assets/Scripts/Audio/AudioManager.cs
+++ b/UOP1_Project/Assets/Scripts/Audio/AudioManager.cs
@@ -90,9 +90,9 @@ public class AudioManager : MonoBehaviour
 
 	private void UnregisterChannel(AudioCueEventChannelSO audioCueEventChannel)
 	{
-		audioCueEventChannel.OnAudioCuePlayRequested += PlayAudioCue;
-		audioCueEventChannel.OnAudioCueStopRequested += StopAudioCue;
-		audioCueEventChannel.OnAudioCueFinishRequested += FinishAudioCue;
+		audioCueEventChannel.OnAudioCuePlayRequested -= PlayAudioCue;
+		audioCueEventChannel.OnAudioCueStopRequested -= StopAudioCue;
+		audioCueEventChannel.OnAudioCueFinishRequested -= FinishAudioCue;
 	}
 
 	// Both MixerValueNormalized and NormalizedToMixerValue functions are used for easier transformations


### PR DESCRIPTION
The `UnregisterChannel` method was not unsubscribing from the delegates properly.

Not sure if this is the right procedure for a small bugfix like this; I didn't think it was worth creating an issue for this