### PR TITLE
Delay loading to accommodate the duration of fade out

### DIFF
--- a/UOP1_Project/Assets/Scenes/Managers/PersistentManagers.unity
+++ b/UOP1_Project/Assets/Scenes/Managers/PersistentManagers.unity
@@ -98,7 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 1
+  m_UseShadowmask: 0
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -511,6 +511,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _fadeChannelSO: {fileID: 11400000, guid: b40bb60f3ca40164e9d7acc6992bae10, type: 2}
   _imageComponent: {fileID: 6952518526949780777}
+  _onFadeComplete: {fileID: 11400000, guid: cdcce1df25c2dbe4e80bee7ffe4e017b, type: 2}
 --- !u!4 &1122701838
 Transform:
   m_ObjectHideFlags: 0
@@ -859,11 +860,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _gameplayScene: {fileID: 11400000, guid: a9c92d087d242344388972b3d1c4aaae, type: 2}
+  _inputReader: {fileID: 11400000, guid: 945ec0365077176418488737deed54be, type: 2}
+  _fadeOutComplete: {fileID: 11400000, guid: cdcce1df25c2dbe4e80bee7ffe4e017b, type: 2}
+  _fadeDuration: 1
   _loadLocation: {fileID: 11400000, guid: 00e3063edc5902e40832ea618644c597, type: 2}
   _loadMenu: {fileID: 11400000, guid: 33cec85652903d245b99985f9cec9841, type: 2}
   _toggleLoadingScreen: {fileID: 11400000, guid: ce8db9fc090944349ba225edb81028d4,
     type: 2}
   _onSceneReady: {fileID: 11400000, guid: b729e40fc41dd8b4ea7aaf5c857f7186, type: 2}
+  _fadeRequest: {fileID: 11400000, guid: b40bb60f3ca40164e9d7acc6992bae10, type: 2}
 --- !u!4 &1416216799
 Transform:
   m_ObjectHideFlags: 0

--- a/UOP1_Project/Assets/ScriptableObjects/Events/UI/FadeCompleteEvent.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/Events/UI/FadeCompleteEvent.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7fafac715ff920c4383fed91a38a351e, type: 3}
+  m_Name: FadeCompleteEvent
+  m_EditorClassIdentifier: 
+  description: 

--- a/UOP1_Project/Assets/ScriptableObjects/Events/UI/FadeCompleteEvent.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/Events/UI/FadeCompleteEvent.asset
@@ -9,7 +9,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7fafac715ff920c4383fed91a38a351e, type: 3}
+  m_Script: {fileID: 11500000, guid: 3177d113f09ae42448cde1e1a5067d4f, type: 3}
   m_Name: FadeCompleteEvent
   m_EditorClassIdentifier: 
-  description: 

--- a/UOP1_Project/Assets/ScriptableObjects/Events/UI/FadeCompleteEvent.asset.meta
+++ b/UOP1_Project/Assets/ScriptableObjects/Events/UI/FadeCompleteEvent.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cdcce1df25c2dbe4e80bee7ffe4e017b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/LoadEventChannelSO.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/LoadEventChannelSO.cs
@@ -8,13 +8,13 @@ using UnityEngine.Events;
 [CreateAssetMenu(menuName = "Events/Load Event Channel")]
 public class LoadEventChannelSO : EventChannelBaseSO
 {
-	public UnityAction<GameSceneSO[], bool> OnLoadingRequested;
+	public UnityAction<GameSceneSO[], bool, bool> OnLoadingRequested;
 
-	public void RaiseEvent(GameSceneSO[] locationsToLoad, bool showLoadingScreen = false)
+	public void RaiseEvent(GameSceneSO[] locationsToLoad, bool showLoadingScreen = false, bool fadeScreen = false)
 	{
 		if (OnLoadingRequested != null)
 		{
-			OnLoadingRequested.Invoke(locationsToLoad, showLoadingScreen);
+			OnLoadingRequested.Invoke(locationsToLoad, showLoadingScreen, fadeScreen);
 		}
 		else
 		{

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/UI/FadeChannelSO.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/UI/FadeChannelSO.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.Events;
 
 [CreateAssetMenu(menuName = "Events/UI/Fade Channel")]

--- a/UOP1_Project/Assets/Scripts/SaveSystem/SaveSystem.cs
+++ b/UOP1_Project/Assets/Scripts/SaveSystem/SaveSystem.cs
@@ -22,7 +22,7 @@ public class SaveSystem : ScriptableObject
 		_loadLocation.OnLoadingRequested -= CacheLoadLocations;
 	}
 
-	private void CacheLoadLocations(GameSceneSO[] locationsToLoad, bool showLoadingScreen)
+	private void CacheLoadLocations(GameSceneSO[] locationsToLoad, bool showLoadingScreen, bool fadeScreen)
 	{
 		LocationSO locationSo = locationsToLoad[0] as LocationSO;
 		if (locationSo)

--- a/UOP1_Project/Assets/Scripts/SceneManagement/LocationExit.cs
+++ b/UOP1_Project/Assets/Scripts/SceneManagement/LocationExit.cs
@@ -9,6 +9,7 @@ public class LocationExit : MonoBehaviour
 	[Header("Loading settings")]
 	[SerializeField] private GameSceneSO[] _locationsToLoad = default;
 	[SerializeField] private bool _showLoadScreen = default;
+	[SerializeField] private bool _fadeScreen = true;
 	[SerializeField] private PathAnchor _pathTaken = default;
 	[SerializeField] private PathSO _exitPath = default;
 
@@ -20,7 +21,7 @@ public class LocationExit : MonoBehaviour
 		if (other.CompareTag("Player"))
 		{
 			UpdatePathTaken();
-			_locationExitLoadChannel.RaiseEvent(_locationsToLoad, _showLoadScreen);
+			_locationExitLoadChannel.RaiseEvent(_locationsToLoad, _showLoadScreen, _fadeScreen);
 		}
 	}
 

--- a/UOP1_Project/Assets/Scripts/SceneManagement/SceneLoader.cs
+++ b/UOP1_Project/Assets/Scripts/SceneManagement/SceneLoader.cs
@@ -114,7 +114,7 @@ public class SceneLoader : MonoBehaviour
 
 		_inputReader.DisableAllInput();
 		if(_fadeScreen)
-			_fadeRequest.Fade(true, _fadeDuration);
+			_fadeRequest.FadeIn(_fadeDuration);
 		else
 			LoadNewScenes();
 
@@ -181,7 +181,7 @@ public class SceneLoader : MonoBehaviour
 			_toggleLoadingScreen.RaiseEvent(false);
 		}
 		if(_fadeScreen)
-			_fadeRequest.Fade(false, _fadeDuration);
+			_fadeRequest.FadeOut(_fadeDuration);
 		else
 			_inputReader.EnableGameplayInput();
 	}

--- a/UOP1_Project/Assets/Scripts/SceneManagement/SceneLoader.cs
+++ b/UOP1_Project/Assets/Scripts/SceneManagement/SceneLoader.cs
@@ -33,6 +33,7 @@ public class SceneLoader : MonoBehaviour
 	private GameSceneSO[] _scenesToLoad;
 	private GameSceneSO[] _currentlyLoadedScenes = new GameSceneSO[] { };
 	private bool _showLoadingScreen;
+	private bool _fadeScreen;
 
 	private SceneInstance _gameplayManagerSceneInstance = new SceneInstance();
 
@@ -53,10 +54,11 @@ public class SceneLoader : MonoBehaviour
 	/// <summary>
 	/// This function loads the location scenes passed as array parameter
 	/// </summary>
-	private void LoadLocation(GameSceneSO[] locationsToLoad, bool showLoadingScreen)
+	private void LoadLocation(GameSceneSO[] locationsToLoad, bool showLoadingScreen, bool fadeScreen)
 	{
 		_scenesToLoad = locationsToLoad;
 		_showLoadingScreen = showLoadingScreen;
+		_fadeScreen = fadeScreen;
 
 		//In case we are coming from the main menu, we need to load the persistent Gameplay manager scene first
 		if (_gameplayManagerSceneInstance.Scene == null
@@ -86,10 +88,11 @@ public class SceneLoader : MonoBehaviour
 	/// <summary>
 	/// Prepares to load the main menu scene, first removing the Gameplay scene in case the game is coming back from gameplay to menus.
 	/// </summary>
-	private void LoadMenu(GameSceneSO[] menusToLoad, bool showLoadingScreen)
+	private void LoadMenu(GameSceneSO[] menusToLoad, bool showLoadingScreen, bool fadeScreen)
 	{
 		_scenesToLoad = menusToLoad;
 		_showLoadingScreen = showLoadingScreen;
+		_fadeScreen = fadeScreen;
 
 		//In case we are coming from a Location back to the main menu, we need to get rid of the persistent Gameplay manager scene
 		if (_gameplayManagerSceneInstance.Scene != null
@@ -110,7 +113,10 @@ public class SceneLoader : MonoBehaviour
 		}
 
 		_inputReader.DisableAllInput();
-		_fadeRequest.Fade(true, _fadeDuration);
+		if(_fadeScreen)
+			_fadeRequest.Fade(true, _fadeDuration);
+		else
+			LoadNewScenes();
 
 	}
 	/// <summary>
@@ -174,8 +180,10 @@ public class SceneLoader : MonoBehaviour
 		{
 			_toggleLoadingScreen.RaiseEvent(false);
 		}
-
-		_fadeRequest.Fade(false, _fadeDuration);
+		if(_fadeScreen)
+			_fadeRequest.Fade(false, _fadeDuration);
+		else
+			_inputReader.EnableGameplayInput();
 	}
 
 	/// <summary>

--- a/UOP1_Project/Assets/Scripts/UI/FadeManager.cs
+++ b/UOP1_Project/Assets/Scripts/UI/FadeManager.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 

--- a/UOP1_Project/Assets/Scripts/UI/FadeManager.cs
+++ b/UOP1_Project/Assets/Scripts/UI/FadeManager.cs
@@ -7,7 +7,7 @@ public class FadeManager : MonoBehaviour
 {
 	[SerializeField] private FadeChannelSO _fadeChannelSO;
 	[SerializeField] private Image _imageComponent;
-	[SerializeField] private VoidEventChannelSO _onFadeComplete;
+	[SerializeField] private BoolEventChannelSO _onFadeComplete;
 
 	private bool _isCurrentlyFading = false;
 
@@ -43,7 +43,7 @@ public class FadeManager : MonoBehaviour
 
 		_imageComponent.color = endColor; //Force to end result
 		_isCurrentlyFading = false;
-		_onFadeComplete.RaiseEvent();
+		_onFadeComplete.RaiseEvent(fadeIn);
 	}
 
 	/// <summary>

--- a/UOP1_Project/Assets/Scripts/UI/FadeManager.cs
+++ b/UOP1_Project/Assets/Scripts/UI/FadeManager.cs
@@ -34,8 +34,7 @@ public class FadeManager : MonoBehaviour
 		while (totalTime <= duration)
 		{
 			totalTime += Time.deltaTime;
-			_imageComponent.color = Color.Lerp(startColor, endColor, totalTime / duration);
-			Debug.Log(_imageComponent.color);
+			_imageComponent.color = Color.Lerp(startColor, endColor, totalTime / duration);			
 
 			yield return null;
 		}

--- a/UOP1_Project/Assets/Scripts/UI/FadeManager.cs
+++ b/UOP1_Project/Assets/Scripts/UI/FadeManager.cs
@@ -7,6 +7,7 @@ public class FadeManager : MonoBehaviour
 {
 	[SerializeField] private FadeChannelSO _fadeChannelSO;
 	[SerializeField] private Image _imageComponent;
+	[SerializeField] private VoidEventChannelSO _onFadeComplete;
 
 	private bool _isCurrentlyFading = false;
 
@@ -27,7 +28,7 @@ public class FadeManager : MonoBehaviour
 	{
 		Color startColor = _imageComponent.color;
 		if (fadeIn)
-			endColor = Color.clear;
+			endColor = Color.black;
 
 		float totalTime = 0f;
 
@@ -35,12 +36,14 @@ public class FadeManager : MonoBehaviour
 		{
 			totalTime += Time.deltaTime;
 			_imageComponent.color = Color.Lerp(startColor, endColor, totalTime / duration);
+			Debug.Log(_imageComponent.color);
 
 			yield return null;
 		}
 
 		_imageComponent.color = endColor; //Force to end result
 		_isCurrentlyFading = false;
+		_onFadeComplete.RaiseEvent();
 	}
 
 	/// <summary>


### PR DESCRIPTION
[Forum Thread](https://forum.unity.com/threads/ui-fader-to-black.1038013/)
This PR links Fade Manager with SceneLoader to enable screen fading during scene loads. Screen is fading when entering different locations, when we are not showing loading screen.
The communication is based on Channel Events.



