### PR TITLE
Refactored RuntimeAnchorBase to be more generic

### DIFF
--- a/UOP1_Project/Assets/Scripts/Camera/CameraManager.cs
+++ b/UOP1_Project/Assets/Scripts/Camera/CameraManager.cs
@@ -11,7 +11,7 @@ public class CameraManager : MonoBehaviour
 	private bool _isRMBPressed;
 
 	[SerializeField, Range(.5f, 3f)]
-	private float _speedMultiplier = 1f; //TODO: make this modifiable in the game settings											
+	private float _speedMultiplier = 1f; //TODO: make this modifiable in the game settings
 	[SerializeField] private TransformAnchor _cameraTransformAnchor = default;
 
 	[Header("Listening on channels")]
@@ -37,7 +37,7 @@ public class CameraManager : MonoBehaviour
 		if (_frameObjectChannel != null)
 			_frameObjectChannel.OnEventRaised += OnFrameObjectEvent;
 
-		_cameraTransformAnchor.Transform = mainCamera.transform;
+		_cameraTransformAnchor.Anchor = mainCamera.transform;
 	}
 
 	private void OnDisable()

--- a/UOP1_Project/Assets/Scripts/Characters/Protagonist.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/Protagonist.cs
@@ -71,12 +71,12 @@ public class Protagonist : MonoBehaviour
 		float targetSpeed = 0f;
 		Vector3 adjustedMovement;
 
-		if (gameplayCameraTransform.isSet)
+		if (gameplayCameraTransform.IsSet)
 		{
 			//Get the two axes from the camera and flatten them on the XZ plane
-			Vector3 cameraForward = gameplayCameraTransform.Transform.forward;
+			Vector3 cameraForward = gameplayCameraTransform.Anchor.forward;
 			cameraForward.y = 0f;
-			Vector3 cameraRight = gameplayCameraTransform.Transform.right;
+			Vector3 cameraRight = gameplayCameraTransform.Anchor.right;
 			cameraRight.y = 0f;
 
 			//Use the two axes, modulated by the corresponding inputs, and construct the final vector

--- a/UOP1_Project/Assets/Scripts/Characters/SlimeCritterAttackController.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/SlimeCritterAttackController.cs
@@ -22,7 +22,7 @@ public class SlimeCritterAttackController : MonoBehaviour
 	// When the attack starts, the position targeted by the attack is determined and is not changed afterward
 	public void SetAttackTarget()
 	{
-		_propelTargetVector = (_playerTransform.Transform.position - transform.position) * _propelFactor / _propelDuration;
+		_propelTargetVector = (_playerTransform.Anchor.position - transform.position) * _propelFactor / _propelDuration;
 	}
 
 	// Trigger the propel movement during the attack

--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/ChasingTargetActionSO.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/ChasingTargetActionSO.cs
@@ -12,7 +12,7 @@ public class ChasingTargetActionSO : StateActionSO
 	[Tooltip("NPC chasing speed")]
 	[SerializeField] private float _chasingSpeed = default;
 
-	public Vector3 TargetPosition => _targetTransform.Transform.position;
+	public Vector3 TargetPosition => _targetTransform.Anchor.position;
 	public float ChasingSpeed => _chasingSpeed;
 
 	protected override StateAction CreateAction() => new ChasingTargetAction();
@@ -34,11 +34,10 @@ public class ChasingTargetAction : StateAction
 
 	public override void OnUpdate()
 	{
-		if (_isActiveAgent)
-		{
-			_agent.isStopped = false;
-			_agent.SetDestination(_config.TargetPosition);
-		}
+		if (!_isActiveAgent) return;
+
+		_agent.isStopped = false;
+		_agent.SetDestination(_config.TargetPosition);
 	}
 
 	public override void OnStateEnter()

--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/FaceProtagonistSO.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/FaceProtagonistSO.cs
@@ -22,14 +22,13 @@ public class FaceProtagonist : StateAction
 
 	public override void OnUpdate()
 	{
-		if (_protagonist.isSet)
-		{
-			Vector3 relativePos = _protagonist.Transform.position - _actor.position;
-			relativePos.y = 0f; // Force rotation to be only on Y axis.
+		if (!_protagonist.IsSet) return;
 
-			Quaternion rotation = Quaternion.LookRotation(relativePos);
-			_actor.rotation = rotation;
-		}
+		Vector3 relativePos = _protagonist.Anchor.position - _actor.position;
+		relativePos.y = 0f; // Force rotation to be only on Y axis.
+
+		Quaternion rotation = Quaternion.LookRotation(relativePos);
+		_actor.rotation = rotation;
 	}
 
 	public override void OnStateEnter()

--- a/UOP1_Project/Assets/Scripts/RuntimeAnchors/PathAnchor.cs
+++ b/UOP1_Project/Assets/Scripts/RuntimeAnchors/PathAnchor.cs
@@ -1,24 +1,6 @@
 ﻿using UnityEngine;
 
 [CreateAssetMenu(fileName = "New PathAnchor", menuName = "Runtime Anchors/Path")]
-public class PathAnchor : RuntimeAnchorBase
+public sealed class PathAnchor : RuntimeAnchorBase<PathSO>
 {
-	[HideInInspector] public bool isSet = false; // Any script can check if the transform is null before using it, by just checking this bool
-
-	private PathSO _Path;
-	public PathSO Path
-	{
-		get { return _Path; }
-		set
-		{
-			_Path = value;
-			isSet = _Path != null;
-		}
-	}
-
-	public void OnDisable()
-	{
-		_Path = null;
-		isSet = false;
-	}
 }

--- a/UOP1_Project/Assets/Scripts/RuntimeAnchors/RuntimeAnchorBase.cs
+++ b/UOP1_Project/Assets/Scripts/RuntimeAnchors/RuntimeAnchorBase.cs
@@ -1,8 +1,37 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using System;
 
-public class RuntimeAnchorBase : ScriptableObject
+/// <summary>Used to loosely couple objects to one another.</summary>
+/// <typeparam name="T">The type of anchor to reference.</typeparam>
+public abstract class RuntimeAnchorBase<T> : DescriptionBaseSO where T : class
 {
-	[TextArea] public string description;
+	/// <summary>We use a weak reference so we don't hold a strong reference to whatever we're anchoring.</summary>
+	private WeakReference<T> _anchor;
+
+	/// <summary>Scripts can check if the anchor is null before using it by checking this bool.</summary>
+	public bool IsSet => _anchor != null;
+
+	/// <summary>Gets or sets the name of the <typeparamref name="T" /> anchor.</summary>
+	/// <exception cref="InvalidOperationException"></exception>
+	public T Anchor
+	{
+		get
+		{
+			if (_anchor.TryGetTarget(out T @out))
+				return @out;
+			throw new InvalidOperationException($"{GetType().Name} anchor has been destroyed.");
+		}
+		set
+		{
+			if (IsSet)
+				_anchor.SetTarget(value);
+			else
+				_anchor = new WeakReference<T>(value);
+		}
+	}
+
+	/// <summary>This function is called when the scriptable object goes out of scope.</summary>
+	public void OnDisable()
+	{
+		_anchor = null;
+	}
 }

--- a/UOP1_Project/Assets/Scripts/RuntimeAnchors/TransformAnchor.cs
+++ b/UOP1_Project/Assets/Scripts/RuntimeAnchors/TransformAnchor.cs
@@ -1,25 +1,6 @@
 ﻿using UnityEngine;
-using System.Collections;
 
 [CreateAssetMenu(menuName = "Runtime Anchors/Transform")]
-public class TransformAnchor : RuntimeAnchorBase
+public sealed class TransformAnchor : RuntimeAnchorBase<Transform>
 {
-	[HideInInspector] public bool isSet = false; // Any script can check if the transform is null before using it, by just checking this bool
-
-	private Transform _transform;
-	public Transform Transform
-	{
-		get { return _transform; }
-		set
-		{
-			_transform = value;
-			isSet = _transform != null;
-		}
-	}
-
-	public void OnDisable()
-	{
-		_transform = null;
-		isSet = false;
-	}
 }

--- a/UOP1_Project/Assets/Scripts/SceneManagement/LocationExit.cs
+++ b/UOP1_Project/Assets/Scripts/SceneManagement/LocationExit.cs
@@ -26,7 +26,7 @@ public class LocationExit : MonoBehaviour
 
 	private void UpdatePathTaken()
 	{
-		if (_pathTaken != null)
-			_pathTaken.Path = _exitPath;
+		if (!_pathTaken.IsSet)
+			_pathTaken.Anchor = _exitPath;
 	}
 }

--- a/UOP1_Project/Assets/Scripts/SpawnSystem.cs
+++ b/UOP1_Project/Assets/Scripts/SpawnSystem.cs
@@ -44,7 +44,7 @@ public class SpawnSystem : MonoBehaviour
 			_spawnLocations[i] = spawnLocationsGO[i].transform;
 		}
 
-		Spawn(_pathTaken.IsSet ? FindSpawnIndex(_pathTaken.Anchor) : FindSpawnIndex(null));
+		Spawn(_pathTaken.IsSet ? FindSpawnIndex(_pathTaken) : FindSpawnIndex(null));
 	}
 
 	void Reset()

--- a/UOP1_Project/Assets/Scripts/SpawnSystem.cs
+++ b/UOP1_Project/Assets/Scripts/SpawnSystem.cs
@@ -43,7 +43,8 @@ public class SpawnSystem : MonoBehaviour
 		{
 			_spawnLocations[i] = spawnLocationsGO[i].transform;
 		}
-		Spawn(FindSpawnIndex(_pathTaken?.Path ?? null));
+
+		Spawn(_pathTaken.IsSet ? FindSpawnIndex(_pathTaken.Anchor) : FindSpawnIndex(null));
 	}
 
 	void Reset()
@@ -69,7 +70,7 @@ public class SpawnSystem : MonoBehaviour
 		Protagonist playerInstance = InstantiatePlayer(_playerPrefab, spawnLocation);
 
 		_playerInstantiatedChannel.RaiseEvent(playerInstance.transform); // The CameraSystem will pick this up to frame the player
-		_playerTransformAnchor.Transform = playerInstance.transform;
+		_playerTransformAnchor.Anchor = playerInstance.transform;
 	}
 
 	private Transform GetSpawnLocation(int index, Transform[] spawnLocations)


### PR DESCRIPTION
Refactored RuntimeAnchorBase to be more generic, along with using a WeakReference (https://docs.microsoft.com/en-us/dotnet/api/system.weakreference-1?view=netstandard-2.0)  so we don't stop garbage collection unnecessarily.

Updated TransformAnchor and PathAnchor to use the more generic RuntimeAnchorBase. I marked them as "Sealed" as nothing is inheriting them for now.

I've made the required changes throughout the code to support those updated anchors.

I made these changes as I was working on another feature and I happened to require some anchors, so in the spirit of the Boy Scouting code rule (https://www.matheus.ro/2017/12/11/clean-code-boy-scout-rule), I felt I should make these changes before moving on.