### PR TITLE
Create save file on editor cold startup if it is not present (allow users to use play mode more than once)

### DIFF
--- a/UOP1_Project/Assets/Prefabs/Gameplay/EditorInitializer.prefab
+++ b/UOP1_Project/Assets/Prefabs/Gameplay/EditorInitializer.prefab
@@ -51,3 +51,4 @@ MonoBehaviour:
     m_SubObjectName: 
     m_SubObjectType: 
     m_EditorAssetChanged: 0
+  _saveSystem: {fileID: 11400000, guid: edc355c4a7d5028408d322b90814e19e, type: 2}

--- a/UOP1_Project/Assets/Scripts/SceneManagement/EditorColdStartup.cs
+++ b/UOP1_Project/Assets/Scripts/SceneManagement/EditorColdStartup.cs
@@ -13,6 +13,7 @@ public class EditorColdStartup : MonoBehaviour
 	[SerializeField] private GameSceneSO _thisSceneSO = default;
 	[SerializeField] private GameSceneSO _persistentManagersSO = default;
 	[SerializeField] private AssetReference _notifyColdStartupChannel = default;
+	[SerializeField] private SaveSystem _saveSystem = default;
 
 	private void Start()
 	{
@@ -20,6 +21,7 @@ public class EditorColdStartup : MonoBehaviour
 		{
 			_persistentManagersSO.sceneReference.LoadSceneAsync(LoadSceneMode.Additive, true).Completed += LoadEventChannel;
 		}
+		CreateSaveFileIfNotPresent();
 	}
 
 	private void LoadEventChannel(AsyncOperationHandle<SceneInstance> obj)
@@ -31,6 +33,14 @@ public class EditorColdStartup : MonoBehaviour
 	{
 		LoadEventChannelSO loadEventChannelSO = (LoadEventChannelSO)_notifyColdStartupChannel.Asset;
 		loadEventChannelSO.RaiseEvent(_thisSceneSO);
+	}
+
+	private void CreateSaveFileIfNotPresent()
+	{
+		if (_saveSystem != null && !_saveSystem.LoadSaveDataFromDisk())
+		{
+			_saveSystem.WriteEmptySaveFile();
+		}
 	}
 #endif
 }

--- a/UOP1_Project/Assets/Scripts/SceneManagement/SceneLoader.cs
+++ b/UOP1_Project/Assets/Scripts/SceneManagement/SceneLoader.cs
@@ -120,9 +120,9 @@ public class SceneLoader : MonoBehaviour
 	/// </summary>
 	private void UnloadPreviousScene()
 	{
-		if(_currentlyLoadedScene != null) //would be null if the game was started in Initialisation
+		if (_currentlyLoadedScene != null) //would be null if the game was started in Initialisation
 		{
-			if(_currentlyLoadedScene.sceneReference.OperationHandle.IsValid())
+			if (_currentlyLoadedScene.sceneReference.OperationHandle.IsValid())
 			{
 				//Unload the scene through its AssetReference, i.e. through the Addressable system
 				_currentlyLoadedScene.sceneReference.UnLoadScene();


### PR DESCRIPTION
I think it makes sense to create the save file on editor cold startup, since we have developers who may play the game without going through the initialization scene.

I first noticed this when trying to enter play mode on the beach scene for the second time. I had no save file present, which caused the beach scene to not fully load and display a "no cameras rendering" message. 

As for how play mode works the first time.... I believe this is due to the async scene loading that we are doing with `EditorColdStartup`. 

The first time you hit play mode, you will observe that the `EditorColdStartup` will call `loadEventChannelSO.RaiseEvent` before the save system has had a chance to subscribe to `_loadLocation.OnLoadingRequested`. Because the save system is not subscribed, we haven't done any saving, so there is no error.

The second time you hit play mode, the save system subscribes to  `_loadLocation.OnLoadingRequested`, and _then_ `EditorColdStartup` will call `loadEventChannelSO.RaiseEvent`.

Async loading shenanigans aside, it makes sense to me to create the save file for devs who use play mode on random scenes. That way, they don't run into save issues.

To Reproduce: 
1. Ensure you have no save file present.
2. Load up any scene besides the initialized scene (I used the beach scene)
3. Press play mode, and then exit
4. Press play mode again
5. Scene will not be fully loaded, and you will see a "no cameras rendering" message.
