### PR TITLE
fix: making the chef walk between rocks

### DIFF
--- a/UOP1_Project/Assets/Prefabs/Characters/PigChef.prefab
+++ b/UOP1_Project/Assets/Prefabs/Characters/PigChef.prefab
@@ -171,7 +171,7 @@ CharacterController:
   serializedVersion: 2
   m_Height: 1.3
   m_Radius: 0.3
-  m_SlopeLimit: 45
+  m_SlopeLimit: 65
   m_StepOffset: 0.05
   m_SkinWidth: 0.02
   m_MinMoveDistance: 0.001


### PR DESCRIPTION
Issue: https://github.com/UnityTechnologies/open-project-1/issues/350
Forum: https://forum.unity.com/threads/the-character-gets-stuck-between-rocks.1050683/

Solution:
- I tried make a minimum modification in the game
- To that, studie all state machine: conditions, actions and transictions
- Checking the IsSlidingCondition I noticed than current slopeLimit its lower for some problematics situations
- So I increased: 45 -> 65 to solve the stucked problem

Verification:

1. Open a scene with the TestingGround. Press play.
2. Jump over the rocks and place the character between them.
3. Try walk, attack and jump to get out of the rocks
