### PR TITLE
fix: checking if the old save file exists

### DIFF
--- a/UOP1_Project/Assets/Scripts/SaveSystem/FileManager.cs
+++ b/UOP1_Project/Assets/Scripts/SaveSystem/FileManager.cs
@@ -48,6 +48,12 @@ public static class FileManager
 			{
 				File.Delete(newFullPath);
 			}
+
+			if (!File.Exists(fullPath))
+			{
+				return false;
+			}
+			
 			File.Move(fullPath, newFullPath);
 		}
 		catch (Exception e)


### PR DESCRIPTION
Issue Link: https://github.com/UnityTechnologies/open-project-1/issues/399
Forum Link: https://forum.unity.com/threads/save-system.1056311/#post-6983891

Solution:

I check if the saved file exists.

* With this current solution, the game doesn't create anymore the save.chop file when the player runs a scene different from the **Initialization** scene

Steps to check if it's ok:

- Remove all save files in the persistence folder (or change temporary the name)
- Open and run the Beach scene
- the game will wok and the save file will not be created
