### PR TITLE
Hotfix for Issue #383 - Slime Critter Pushing Player Excessively

### DIFF
--- a/UOP1_Project/Assets/Prefabs/Characters/SlimeCritter_Base.prefab
+++ b/UOP1_Project/Assets/Prefabs/Characters/SlimeCritter_Base.prefab
@@ -58,6 +58,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _attackConfigSO: {fileID: 11400000, guid: fa67200955f70e64abecdd0107951472, type: 2}
+  onHit:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2038924309811281612}
+        m_TargetAssemblyTypeName: SlimeCritterAttackController, Assembly-CSharp
+        m_MethodName: StopAttack
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!135 &6188918218575104391
 SphereCollider:
   m_ObjectHideFlags: 0

--- a/UOP1_Project/Assets/Scripts/Characters/Attack.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/Attack.cs
@@ -1,10 +1,13 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Events;
 
 public class Attack : MonoBehaviour
 {
 	[SerializeField] private AttackConfigSO _attackConfigSO;
+	[SerializeField] [Tooltip("Any additional events to be called upon a successful hit")]
+	private UnityEvent onHit;
 
 	public AttackConfigSO AttackConfig => _attackConfigSO;
 
@@ -21,7 +24,11 @@ public class Attack : MonoBehaviour
 			if (other.TryGetComponent(out Damageable damageableComp))
 			{
 				if (!damageableComp.GetHit)
+				{
 					damageableComp.ReceiveAnAttack(_attackConfigSO.AttackStrength);
+					// Invoke any necessary hit events
+					onHit?.Invoke();
+				}
 			}
 		}
 	}

--- a/UOP1_Project/Assets/Scripts/Characters/SlimeCritterAttackController.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/SlimeCritterAttackController.cs
@@ -40,4 +40,10 @@ public class SlimeCritterAttackController : MonoBehaviour
 			_innerTime -= Time.deltaTime;
 		}
 	}
+
+	public void StopAttack()
+	{
+		// Reset innerTime
+		_innerTime = 0.0f;
+	}
 }


### PR DESCRIPTION
Bugfix for issues #383 and #349: [Forum Thread](https://forum.unity.com/threads/the-slime-critter-attack-throws-the-player-several-meters-away.1050692/#post-7016377)
This issue was caused by the player and Slime colliders overlapping after the player's hit reaction plays, causing it to be pushed backward. The simple fix for this was to simply stop the Slime from moving forward during its attack if it already hit the player. For starters, I created a UnityEvent to be called during successful hit in OnTriggerEnter for the Attack class. Then on the Slime prefab I linked the UnityEvent to call a public method in the SlimeAttackController that simply stops the timer that controls its positional updates during its attack.

This can be tested by getting attacked by a Slime while up against the short rocks near the house in the TestingGround scene, the player is no longer pushed upwards and maintains its position after hit reaction finishes
