### PR TITLE
I'm curious why the AO handle result is not used in this context?

### DIFF
--- a/UOP1_Project/Assets/Scripts/SceneManagement/InitializationLoader.cs
+++ b/UOP1_Project/Assets/Scripts/SceneManagement/InitializationLoader.cs
@@ -30,8 +30,7 @@ public class InitializationLoader : MonoBehaviour
 
 	private void LoadMainMenu(AsyncOperationHandle<LoadEventChannelSO> obj)
 	{
-		LoadEventChannelSO loadEventChannelSO = (LoadEventChannelSO)_menuLoadChannel.Asset;
-		loadEventChannelSO.RaiseEvent(_menuToLoad);
+		obj.Result.RaiseEvent(_menuToLoad);
 
 		SceneManager.UnloadSceneAsync(0); //Initialization is the only scene in BuildSettings, thus it has index 0
 	}


### PR DESCRIPTION
Question:

I recently learned about open projects from dev blog 4 because of the addressables system (as i'm looking to implement a similar loading strategy) and i'm digging through the Initialization code and i'm wondering why the Async Operation Handle Result is not used?  Here is a PR that switches to using the Async Operation Handle Result - is this the more correct paradigm?


