### PR TITLE
[Bugfix] New condition prevents Critter from attacking when dialogue on

### DIFF
--- a/UOP1_Project/Assets/Scenes/WIP/TestingGround.unity
+++ b/UOP1_Project/Assets/Scenes/WIP/TestingGround.unity
@@ -1460,7 +1460,7 @@ PrefabInstance:
     - target: {fileID: 8341946629798114147, guid: 0b4e286cfc4c6e943841c36cc5529b22,
         type: 3}
       propertyPath: m_RootOrder
-      value: 38
+      value: 37
       objectReference: {fileID: 0}
     - target: {fileID: 8341946629798114147, guid: 0b4e286cfc4c6e943841c36cc5529b22,
         type: 3}
@@ -12400,7 +12400,7 @@ PrefabInstance:
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
       propertyPath: m_RootOrder
-      value: 35
+      value: 34
       objectReference: {fileID: 0}
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
@@ -19390,7 +19390,7 @@ Transform:
   m_LocalScale: {x: 7.1086464, y: 3.4087424, z: 1.5580586}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 26
+  m_RootOrder: 25
   m_LocalEulerAnglesHint: {x: 0, y: 112.86, z: 0}
 --- !u!114 &484043360
 MonoBehaviour:
@@ -38119,7 +38119,7 @@ PrefabInstance:
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
       propertyPath: m_RootOrder
-      value: 37
+      value: 36
       objectReference: {fileID: 0}
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
@@ -39582,7 +39582,7 @@ PrefabInstance:
     - target: {fileID: 2723178623857253410, guid: 7f3c311f1ca46334ab26b1adfc5be02f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 33
+      value: 32
       objectReference: {fileID: 0}
     - target: {fileID: 2723178623857253410, guid: 7f3c311f1ca46334ab26b1adfc5be02f,
         type: 3}
@@ -40800,7 +40800,7 @@ PrefabInstance:
     - target: {fileID: 259315596768083755, guid: 7b73a01faf37c4c4c90a48a01f6e3233,
         type: 3}
       propertyPath: m_RootOrder
-      value: 27
+      value: 26
       objectReference: {fileID: 0}
     - target: {fileID: 259315596768083755, guid: 7b73a01faf37c4c4c90a48a01f6e3233,
         type: 3}
@@ -49014,7 +49014,7 @@ PrefabInstance:
     - target: {fileID: 2126586097156616352, guid: 0f60adbc96570cb4e9898a0409956f1d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 31
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 2126586097156616352, guid: 0f60adbc96570cb4e9898a0409956f1d,
         type: 3}
@@ -50649,7 +50649,7 @@ PrefabInstance:
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
       propertyPath: m_RootOrder
-      value: 34
+      value: 33
       objectReference: {fileID: 0}
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
@@ -54730,7 +54730,7 @@ PrefabInstance:
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
       propertyPath: m_RootOrder
-      value: 36
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
@@ -55749,7 +55749,7 @@ PrefabInstance:
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
       propertyPath: m_RootOrder
-      value: 28
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
@@ -56943,53 +56943,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1166061464}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1166404011
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1166404013}
-  - component: {fileID: 1166404012}
-  m_Layer: 0
-  m_Name: test
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1166404012
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1166404011}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b23dda2a525f44a589afbef864da0d7c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _startDialogueEvent: {fileID: 11400000, guid: 5cfe626f5482b914a9e46ebbe35ea1a8,
-    type: 2}
-  _endDialogueEvent: {fileID: 11400000, guid: b8f14d59bc3b10e4f9bdf1e65c3c6280, type: 2}
-  _isDialogueOn: 0
---- !u!4 &1166404013
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1166404011}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 25
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1171344013
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -83765,12 +83718,12 @@ PrefabInstance:
     - target: {fileID: 2808035858438402709, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.07621856
+      value: 0.07621853
       objectReference: {fileID: 0}
     - target: {fileID: 2808035858438402709, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.017992763
+      value: -0.017992755
       objectReference: {fileID: 0}
     - target: {fileID: 2955398947125553842, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
@@ -83800,12 +83753,12 @@ PrefabInstance:
     - target: {fileID: 2955398947125553842, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.07621856
+      value: 0.07621853
       objectReference: {fileID: 0}
     - target: {fileID: 2955398947125553842, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.017992763
+      value: -0.017992755
       objectReference: {fileID: 0}
     - target: {fileID: 8745341640208226293, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
@@ -87150,7 +87103,7 @@ PrefabInstance:
     - target: {fileID: 8815571646897690619, guid: 963eb11d04d7192468b645c523fcab8f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 30
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 8815571646897690619, guid: 963eb11d04d7192468b645c523fcab8f,
         type: 3}
@@ -89609,7 +89562,7 @@ PrefabInstance:
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
       propertyPath: m_RootOrder
-      value: 29
+      value: 28
       objectReference: {fileID: 0}
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
@@ -90718,7 +90671,7 @@ PrefabInstance:
     - target: {fileID: 259315596768083755, guid: 7b73a01faf37c4c4c90a48a01f6e3233,
         type: 3}
       propertyPath: m_RootOrder
-      value: 32
+      value: 31
       objectReference: {fileID: 0}
     - target: {fileID: 259315596768083755, guid: 7b73a01faf37c4c4c90a48a01f6e3233,
         type: 3}

--- a/UOP1_Project/Assets/Scenes/WIP/TestingGround.unity
+++ b/UOP1_Project/Assets/Scenes/WIP/TestingGround.unity
@@ -1460,7 +1460,7 @@ PrefabInstance:
     - target: {fileID: 8341946629798114147, guid: 0b4e286cfc4c6e943841c36cc5529b22,
         type: 3}
       propertyPath: m_RootOrder
-      value: 37
+      value: 38
       objectReference: {fileID: 0}
     - target: {fileID: 8341946629798114147, guid: 0b4e286cfc4c6e943841c36cc5529b22,
         type: 3}
@@ -12400,7 +12400,7 @@ PrefabInstance:
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
       propertyPath: m_RootOrder
-      value: 34
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
@@ -19390,7 +19390,7 @@ Transform:
   m_LocalScale: {x: 7.1086464, y: 3.4087424, z: 1.5580586}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 25
+  m_RootOrder: 26
   m_LocalEulerAnglesHint: {x: 0, y: 112.86, z: 0}
 --- !u!114 &484043360
 MonoBehaviour:
@@ -38119,7 +38119,7 @@ PrefabInstance:
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
       propertyPath: m_RootOrder
-      value: 36
+      value: 37
       objectReference: {fileID: 0}
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
@@ -39582,7 +39582,7 @@ PrefabInstance:
     - target: {fileID: 2723178623857253410, guid: 7f3c311f1ca46334ab26b1adfc5be02f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 32
+      value: 33
       objectReference: {fileID: 0}
     - target: {fileID: 2723178623857253410, guid: 7f3c311f1ca46334ab26b1adfc5be02f,
         type: 3}
@@ -40800,7 +40800,7 @@ PrefabInstance:
     - target: {fileID: 259315596768083755, guid: 7b73a01faf37c4c4c90a48a01f6e3233,
         type: 3}
       propertyPath: m_RootOrder
-      value: 26
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 259315596768083755, guid: 7b73a01faf37c4c4c90a48a01f6e3233,
         type: 3}
@@ -49014,7 +49014,7 @@ PrefabInstance:
     - target: {fileID: 2126586097156616352, guid: 0f60adbc96570cb4e9898a0409956f1d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 30
+      value: 31
       objectReference: {fileID: 0}
     - target: {fileID: 2126586097156616352, guid: 0f60adbc96570cb4e9898a0409956f1d,
         type: 3}
@@ -50649,7 +50649,7 @@ PrefabInstance:
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
       propertyPath: m_RootOrder
-      value: 33
+      value: 34
       objectReference: {fileID: 0}
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
@@ -54730,7 +54730,7 @@ PrefabInstance:
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
       propertyPath: m_RootOrder
-      value: 35
+      value: 36
       objectReference: {fileID: 0}
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
@@ -55749,7 +55749,7 @@ PrefabInstance:
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
       propertyPath: m_RootOrder
-      value: 27
+      value: 28
       objectReference: {fileID: 0}
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
@@ -56943,6 +56943,53 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1166061464}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1166404011
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1166404013}
+  - component: {fileID: 1166404012}
+  m_Layer: 0
+  m_Name: test
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1166404012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1166404011}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b23dda2a525f44a589afbef864da0d7c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _startDialogueEvent: {fileID: 11400000, guid: 5cfe626f5482b914a9e46ebbe35ea1a8,
+    type: 2}
+  _endDialogueEvent: {fileID: 11400000, guid: b8f14d59bc3b10e4f9bdf1e65c3c6280, type: 2}
+  _isDialogueOn: 0
+--- !u!4 &1166404013
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1166404011}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 25
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1171344013
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -83753,12 +83800,12 @@ PrefabInstance:
     - target: {fileID: 2955398947125553842, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.07621853
+      value: 0.07621856
       objectReference: {fileID: 0}
     - target: {fileID: 2955398947125553842, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.017992755
+      value: -0.017992763
       objectReference: {fileID: 0}
     - target: {fileID: 8745341640208226293, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
@@ -83843,7 +83890,7 @@ PrefabInstance:
     - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9702599
+      value: 0.97025996
       objectReference: {fileID: 0}
     - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
@@ -83853,7 +83900,7 @@ PrefabInstance:
     - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.07621856
+      value: 0.07621857
       objectReference: {fileID: 0}
     - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
@@ -87103,7 +87150,7 @@ PrefabInstance:
     - target: {fileID: 8815571646897690619, guid: 963eb11d04d7192468b645c523fcab8f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 29
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 8815571646897690619, guid: 963eb11d04d7192468b645c523fcab8f,
         type: 3}
@@ -89562,7 +89609,7 @@ PrefabInstance:
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
       propertyPath: m_RootOrder
-      value: 28
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 8221149608678237085, guid: 9f7b0cb7955c190418da560e89736c38,
         type: 3}
@@ -90671,7 +90718,7 @@ PrefabInstance:
     - target: {fileID: 259315596768083755, guid: 7b73a01faf37c4c4c90a48a01f6e3233,
         type: 3}
       propertyPath: m_RootOrder
-      value: 31
+      value: 32
       objectReference: {fileID: 0}
     - target: {fileID: 259315596768083755, guid: 7b73a01faf37c4c4c90a48a01f6e3233,
         type: 3}

--- a/UOP1_Project/Assets/Scenes/WIP/TestingGround.unity
+++ b/UOP1_Project/Assets/Scenes/WIP/TestingGround.unity
@@ -83718,12 +83718,12 @@ PrefabInstance:
     - target: {fileID: 2808035858438402709, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.07621853
+      value: 0.07621856
       objectReference: {fileID: 0}
     - target: {fileID: 2808035858438402709, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.017992755
+      value: -0.017992763
       objectReference: {fileID: 0}
     - target: {fileID: 2955398947125553842, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
@@ -83843,7 +83843,7 @@ PrefabInstance:
     - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.97025996
+      value: 0.9702599
       objectReference: {fileID: 0}
     - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
@@ -83853,7 +83853,7 @@ PrefabInstance:
     - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.07621857
+      value: 0.07621856
       objectReference: {fileID: 0}
     - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
         type: 3}

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Critters/Conditions/IsDialogueActiveCondition.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Critters/Conditions/IsDialogueActiveCondition.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5be74e14d569340ea88bda4cb6de35da, type: 3}
+  m_Name: IsDialogueActiveCondition
+  m_EditorClassIdentifier: 
+  _startDialogueEvent: {fileID: 11400000, guid: 5cfe626f5482b914a9e46ebbe35ea1a8,
+    type: 2}
+  _endDialogueEvent: {fileID: 11400000, guid: b8f14d59bc3b10e4f9bdf1e65c3c6280, type: 2}

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Critters/Conditions/IsDialogueActiveCondition.asset.meta
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Critters/Conditions/IsDialogueActiveCondition.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 050fbbaa48ac74961952b20dabfd6e88
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Critters/SlimeRockCritter/SlimeRockCritter_TransitionTable.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Critters/SlimeRockCritter/SlimeRockCritter_TransitionTable.asset
@@ -22,6 +22,9 @@ MonoBehaviour:
     - ExpectedResult: 0
       Condition: {fileID: 11400000, guid: 27c06ead5f7a1ed4d89197fe9a61d0c2, type: 2}
       Operator: 0
+    - ExpectedResult: 1
+      Condition: {fileID: 11400000, guid: 050fbbaa48ac74961952b20dabfd6e88, type: 2}
+      Operator: 0
   - FromState: {fileID: 11400000, guid: ea7a8e48b1a87c241bb721da98d1d812, type: 2}
     ToState: {fileID: 11400000, guid: 5b0e38103a74c054cb968153b3227b71, type: 2}
     Conditions:
@@ -132,6 +135,9 @@ MonoBehaviour:
     Conditions:
     - ExpectedResult: 0
       Condition: {fileID: 11400000, guid: 27c06ead5f7a1ed4d89197fe9a61d0c2, type: 2}
+      Operator: 0
+    - ExpectedResult: 1
+      Condition: {fileID: 11400000, guid: 050fbbaa48ac74961952b20dabfd6e88, type: 2}
       Operator: 0
   - FromState: {fileID: 11400000, guid: 658f06f54a3654c498a26d9714beaff0, type: 2}
     ToState: {fileID: 11400000, guid: 05826b0374eccc245b9b1da390ab7d04, type: 2}

--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Conditions/IsDialogueActiveConditionSO.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Conditions/IsDialogueActiveConditionSO.cs
@@ -1,0 +1,67 @@
+﻿using UnityEngine;
+using UOP1.StateMachine;
+using UOP1.StateMachine.ScriptableObjects;
+
+[CreateAssetMenu(fileName = "IsDialogueActiveCondition", menuName = "State Machines/Conditions/Is Dialogue Active Condition")]
+public class IsDialogueActiveConditionSO : StateConditionSO
+{
+	[SerializeField] private DialogueDataChannelSO _startDialogueEvent = default;
+	[SerializeField] private DialogueDataChannelSO _endDialogueEvent = default;
+
+	protected override Condition CreateCondition() => new IsDialogueActiveCondition(_startDialogueEvent, _endDialogueEvent);
+
+}
+
+public class IsDialogueActiveCondition : Condition
+{
+	private DialogueDataChannelSO _startDialogueEvent;
+	private DialogueDataChannelSO _endDialogueEvent;
+	private bool _isDialogueActive = false;
+
+	public IsDialogueActiveCondition(DialogueDataChannelSO startDialogueEvent, DialogueDataChannelSO endDialogueEvent)
+	{
+		_startDialogueEvent = startDialogueEvent;
+		_endDialogueEvent = endDialogueEvent;
+	}
+
+	protected override bool Statement()
+	{
+		return _isDialogueActive;
+	}
+
+	public override void OnStateEnter()
+	{
+		if (_startDialogueEvent != null)
+		{
+			_startDialogueEvent.OnEventRaised += OnDialogueStart;
+		}
+
+		if (_endDialogueEvent != null)
+		{
+			_endDialogueEvent.OnEventRaised += OnDialogueEnd;
+		}
+	}
+
+	public override void OnStateExit()
+	{
+		if (_startDialogueEvent != null)
+		{
+			_startDialogueEvent.OnEventRaised -= OnDialogueStart;
+		}
+
+		if (_endDialogueEvent != null)
+		{
+			_endDialogueEvent.OnEventRaised -= OnDialogueEnd;
+		}
+	}
+
+	private void OnDialogueStart(DialogueDataSO dialogue)
+	{
+		_isDialogueActive = true;
+	}
+
+	private void OnDialogueEnd(DialogueDataSO dialogue)
+	{
+		_isDialogueActive = false;
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Conditions/IsDialogueActiveConditionSO.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Conditions/IsDialogueActiveConditionSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5be74e14d569340ea88bda4cb6de35da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Issue:https://github.com/UnityTechnologies/open-project-1/issues/418
Forum: https://forum.unity.com/threads/bug-enemy-attacks-protagonist-during-a-dialogue.1103305/

This PR has two main changes:
1. Introduce `IsDialogueActive` Condition
2. Updates `Slime Critter` state machine to include aforementioned Condition in transition from `Idle` or `Roaming` state to `Alert` state

`IsDialogueActive`Condtion simply listens to Start and End dialog events emitted by Dialogue Manager. It preserves internal boolean value that becomes truthful when the new dialogue starts, falsy when dialogue ends. Assuming we may have only one active dialogue at a time, Condition should correctly indicate if there is any dialogue active currently. Finally,` Condition` uses that internal value as a result of `Statement`

Notice that Critter now keeps roaming without disturbing Hamlet who's busy in the convo with townsfolk:

![chop-chop-critter-keeps-roaming](https://user-images.githubusercontent.com/5962670/116833137-7f51cf00-ab85-11eb-96c4-ee25466a8125.gif)
