### PR TITLE
Event Aggregator proposal

### DIFF
--- a/UOP1_Project/Assets/Prefabs/Characters/PigChef.prefab
+++ b/UOP1_Project/Assets/Prefabs/Characters/PigChef.prefab
@@ -361,6 +361,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _inputReader: {fileID: 11400000, guid: 945ec0365077176418488737deed54be, type: 2}
+  _eventAggregator: {fileID: 11400000, guid: c92bfb91ff27b83459c86d7413b0081a, type: 2}
   gameplayCameraTransform: {fileID: 11400000, guid: bc205269957643647a8b5f98f028f9fb,
     type: 2}
   _openInventoryChannel: {fileID: 11400000, guid: 30f6db2122a30480b996908173e1c7d7,

--- a/UOP1_Project/Assets/Prefabs/Gameplay/CameraSystem.prefab
+++ b/UOP1_Project/Assets/Prefabs/Gameplay/CameraSystem.prefab
@@ -779,7 +779,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 085156cba0e34b540aeddafe12d1e2f1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  inputReader: {fileID: 11400000, guid: 945ec0365077176418488737deed54be, type: 2}
+  eventBus: {fileID: 11400000, guid: b4774447b4f72b8408dbd98248f139ca, type: 2}
   mainCamera: {fileID: 8745341642014614481}
   freeLookVCam: {fileID: 8745341641394998849}
   _speedMultiplier: 0.5

--- a/UOP1_Project/Assets/ScriptableObjects/Events/EventAggregatorSO.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/Events/EventAggregatorSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c3683d4b74c443d4a48ca7b36086f246, type: 3}
+  m_Name: EventAggregatorSO
+  m_EditorClassIdentifier: 

--- a/UOP1_Project/Assets/ScriptableObjects/Events/EventAggregatorSO.asset.meta
+++ b/UOP1_Project/Assets/ScriptableObjects/Events/EventAggregatorSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c92bfb91ff27b83459c86d7413b0081a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/ScriptableObjects/Events/UnityEventBusSO.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/Events/UnityEventBusSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c44145970255443c86929d77c7ac2d2a, type: 3}
+  m_Name: UnityEventBusSO
+  m_EditorClassIdentifier: 

--- a/UOP1_Project/Assets/ScriptableObjects/Events/UnityEventBusSO.asset.meta
+++ b/UOP1_Project/Assets/ScriptableObjects/Events/UnityEventBusSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b4774447b4f72b8408dbd98248f139ca
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Characters/Protagonist.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/Protagonist.cs
@@ -1,12 +1,21 @@
 ﻿using System;
 using UnityEngine;
+using static EventAggregator;
 
 /// <summary>
 /// <para>This component consumes input on the InputReader and stores its values. The input is then read, and manipulated, by the StateMachines's Actions.</para>
 /// </summary>
-public class Protagonist : MonoBehaviour
+public class Protagonist : MonoBehaviour,
+	IHandle<AttackEvent>,
+	IHandle<JumpEvent>,
+	IHandle<JumpCancelledEvent>,
+	IHandle<MoveEvent>,
+	IHandle<StartedRunningEvent>,
+	IHandle<StoppedRunningEvent>,
+	IHandle<OpenInventoryEvent>
 {
-	[SerializeField] private InputReader _inputReader = default;
+	[SerializeField] private EventAggregatorSO _eventAggregator;
+
 	public TransformAnchor gameplayCameraTransform;
 
 	[SerializeField] private VoidEventChannelSO _openInventoryChannel = default;
@@ -38,27 +47,13 @@ public class Protagonist : MonoBehaviour
 	//Adds listeners for events being triggered in the InputReader script
 	private void OnEnable()
 	{
-		_inputReader.jumpEvent += OnJumpInitiated;
-		_inputReader.jumpCanceledEvent += OnJumpCanceled;
-		_inputReader.moveEvent += OnMove;
-		_inputReader.openInventoryEvent += OnOpenInventory;
-		_inputReader.startedRunning += OnStartedRunning;
-		_inputReader.stoppedRunning += OnStoppedRunning;
-		_inputReader.attackEvent += OnStartedAttack;
-		//...
+		_eventAggregator.Subscribe(this);
 	}
 
 	//Removes all listeners to the events coming from the InputReader script
 	private void OnDisable()
 	{
-		_inputReader.jumpEvent -= OnJumpInitiated;
-		_inputReader.jumpCanceledEvent -= OnJumpCanceled;
-		_inputReader.moveEvent -= OnMove;
-		_inputReader.openInventoryEvent -= OnOpenInventory;
-		_inputReader.startedRunning -= OnStartedRunning;
-		_inputReader.stoppedRunning -= OnStoppedRunning;
-		_inputReader.attackEvent -= OnStartedAttack;
-		//...
+		_eventAggregator.Unsubscribe(this);
 	}
 
 	private void Update()
@@ -107,37 +102,42 @@ public class Protagonist : MonoBehaviour
 		_previousSpeed = targetSpeed;
 	}
 
-	//---- EVENT LISTENERS ----
+	// Triggered from Animation Event
+	public void ConsumeAttackInput() => attackInput = false;
 
-	private void OnMove(Vector2 movement)
+	public void Handle(AttackEvent msg)
 	{
-		_inputVector = movement;
+		attackInput = true;
 	}
 
-	private void OnJumpInitiated()
+	public void Handle(JumpEvent msg)
 	{
 		jumpInput = true;
 	}
 
-	private void OnJumpCanceled()
+	public void Handle(JumpCancelledEvent msg)
 	{
 		jumpInput = false;
 	}
 
-	private void OnStoppedRunning() => isRunning = false;
-
-	private void OnStartedRunning() => isRunning = true;
-
-	private void OnOpenInventory()
+	public void Handle(MoveEvent msg)
 	{
-		_openInventoryChannel.RaiseEvent();
-
-
+		_inputVector = msg.Movement;
 	}
 
+	public void Handle(StartedRunningEvent msg)
+	{
+		isRunning = true;
+	}
 
-	private void OnStartedAttack() => attackInput = true;
+	public void Handle(StoppedRunningEvent msg)
+	{
+		isRunning = false;
+	}
 
-	// Triggered from Animation Event
-	public void ConsumeAttackInput() => attackInput = false;
+	public void Handle(OpenInventoryEvent msg)
+	{	// Clearly this event should be handled elsewhere and not on the
+		// protagonist but for now limited changes.
+		_openInventoryChannel.RaiseEvent();
+	}
 }

--- a/UOP1_Project/Assets/Scripts/Events/EventAggregator.cs
+++ b/UOP1_Project/Assets/Scripts/Events/EventAggregator.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+
+/// <summary>
+/// Enables loose coupling of events from publishers to subscribers
+///
+/// inspired from https://github.com/Caliburn-Micro/Caliburn.Micro/blob/master/src/Caliburn.Micro.Core/IEventAggregator.cs
+/// and also https://github.com/google/guava/blob/master/guava/src/com/google/common/eventbus/EventBus.java
+///
+/// Runs within single threaded unity environment so no need to lock any structures.
+/// There is no current requirement to dispatch or consume events asynchronously and sync with unity main thread.
+/// </summary>
+public interface IEventAggregator
+{
+	void Subscribe(object observer);
+
+	void Unsubscribe(object observer);
+
+	void Publish(object msg);
+}
+
+public class EventAggregator : IEventAggregator
+{
+	private readonly Dictionary<Type, HashSet<Handler>> _handlers = new Dictionary<Type, HashSet<Handler>>();
+	private readonly Dictionary<object, Subscriptions> _subByObserver = new Dictionary<object, Subscriptions>();
+	private readonly object[] _paramHolder = {null};
+
+	public void Subscribe(object observer)
+	{
+		if (observer == null)
+		{
+			throw new ArgumentNullException(nameof(observer));
+		}
+
+		if (_subByObserver.ContainsKey(observer))
+		{
+			return;
+		}
+
+		var subs = new Subscriptions();
+
+		var interfaces = observer.GetType().GetTypeInfo().ImplementedInterfaces
+			.Where(x => x.GetTypeInfo().IsGenericType && x.GetGenericTypeDefinition() == typeof(IHandle<>));
+
+		foreach (var @interface in interfaces)
+		{
+			var type = @interface.GetTypeInfo().GenericTypeArguments[0];
+			var method = @interface.GetRuntimeMethod("Handle", new[] {type});
+
+			if (method != null)
+			{
+				var handler = new Handler(method, observer);
+
+				if (!_handlers.TryGetValue(type, out var handlers))
+				{
+					handlers = new HashSet<Handler>();
+					_handlers[type] = handlers;
+				}
+
+				handlers.Add(handler);
+				subs.Interested[type] = handler;
+			}
+		}
+
+		if (subs.Interested.Count > 0)
+		{
+			_subByObserver[observer] = subs;
+		}
+	}
+
+	public void Unsubscribe(object observer)
+	{
+		if (observer == null)
+		{
+			throw new ArgumentNullException(nameof(observer));
+		}
+
+
+		if (_subByObserver.TryGetValue(observer, out var subscriptions))
+		{
+			_subByObserver.Remove(observer);
+
+			foreach (var entry in subscriptions.Interested)
+			{
+				if (_handlers.TryGetValue(entry.Key, out var handlers))
+				{
+					handlers.Remove(entry.Value);
+				}
+			}
+		}
+	}
+
+	public void Publish(object msg)
+	{
+		if (msg == null)
+		{
+			throw new ArgumentNullException(nameof(msg));
+		}
+
+		if (_handlers.TryGetValue(msg.GetType(), out var handlers))
+		{
+			_paramHolder[0] = msg;
+
+			foreach (var handler in handlers)
+			{
+				handler.Notify(_paramHolder);
+			}
+		}
+	}
+
+	private class Subscriptions
+	{
+		private readonly Dictionary<Type, Handler> _interested = new Dictionary<Type, Handler>();
+
+		public Dictionary<Type, Handler> Interested => _interested;
+	}
+
+	private class Handler
+	{
+		private readonly MethodInfo _method;
+		private readonly object _observer;
+
+		public Handler(MethodInfo method, object observer)
+		{
+			_method = method;
+			_observer = observer;
+		}
+
+		public void Notify(object[] param)
+		{
+			_method.Invoke(_observer, param);
+		}
+	}
+
+	public interface IHandle<T>
+	{
+		void Handle(T msg);
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Events/EventAggregator.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Events/EventAggregator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa8b4461b92ba7c4a86bd2a8f0f89d5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Events/Input.meta
+++ b/UOP1_Project/Assets/Scripts/Events/Input.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bc1d749a583a49548d472953a83cdefc
+timeCreated: 1620200166

--- a/UOP1_Project/Assets/Scripts/Events/Input/AttackCancelledEvent.cs
+++ b/UOP1_Project/Assets/Scripts/Events/Input/AttackCancelledEvent.cs
@@ -1,0 +1,4 @@
+﻿public class AttackCancelledEvent
+{
+	public static readonly AttackCancelledEvent Event = new AttackCancelledEvent();
+}

--- a/UOP1_Project/Assets/Scripts/Events/Input/AttackCancelledEvent.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Events/Input/AttackCancelledEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0f40b4b3b23e4ea287f06b483995f27a
+timeCreated: 1620200355

--- a/UOP1_Project/Assets/Scripts/Events/Input/AttackEvent.cs
+++ b/UOP1_Project/Assets/Scripts/Events/Input/AttackEvent.cs
@@ -1,0 +1,4 @@
+﻿public class AttackEvent
+{
+	public static readonly AttackEvent Event = new AttackEvent();
+}

--- a/UOP1_Project/Assets/Scripts/Events/Input/AttackEvent.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Events/Input/AttackEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9c6d9f27a8cb4aefad8e71c45ac9f57f
+timeCreated: 1620200178

--- a/UOP1_Project/Assets/Scripts/Events/Input/CameraMoveEvent.cs
+++ b/UOP1_Project/Assets/Scripts/Events/Input/CameraMoveEvent.cs
@@ -1,0 +1,7 @@
+﻿using UnityEngine;
+
+public class CameraMoveEvent
+{
+	public Vector2 Movement { get; set; }
+	public bool IsDeviceMouse { get; set; }
+}

--- a/UOP1_Project/Assets/Scripts/Events/Input/CameraMoveEvent.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Events/Input/CameraMoveEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 09da76db91954356a35ef2e359f00813
+timeCreated: 1620210604

--- a/UOP1_Project/Assets/Scripts/Events/Input/DisableMouseControlEvent.cs
+++ b/UOP1_Project/Assets/Scripts/Events/Input/DisableMouseControlEvent.cs
@@ -1,0 +1,4 @@
+﻿public class DisableMouseControlEvent
+{
+	public static readonly DisableMouseControlEvent Event = new DisableMouseControlEvent();
+}

--- a/UOP1_Project/Assets/Scripts/Events/Input/DisableMouseControlEvent.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Events/Input/DisableMouseControlEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a0ce839adb8f4d57a335a10105cef5d3
+timeCreated: 1620211722

--- a/UOP1_Project/Assets/Scripts/Events/Input/EnableMouseControlEvent.cs
+++ b/UOP1_Project/Assets/Scripts/Events/Input/EnableMouseControlEvent.cs
@@ -1,0 +1,4 @@
+﻿public class EnableMouseControlEvent
+{
+	public static readonly EnableMouseControlEvent Event = new EnableMouseControlEvent();
+}

--- a/UOP1_Project/Assets/Scripts/Events/Input/EnableMouseControlEvent.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Events/Input/EnableMouseControlEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0559f4ea2ee34ba997d7bc29f8e55f06
+timeCreated: 1620211696

--- a/UOP1_Project/Assets/Scripts/Events/Input/JumpCancelledEvent.cs
+++ b/UOP1_Project/Assets/Scripts/Events/Input/JumpCancelledEvent.cs
@@ -1,0 +1,4 @@
+﻿public class JumpCancelledEvent
+{
+	public static readonly JumpCancelledEvent Event = new JumpCancelledEvent();
+}

--- a/UOP1_Project/Assets/Scripts/Events/Input/JumpCancelledEvent.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Events/Input/JumpCancelledEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f07eb2adec604dd98b11900b0907f9e9
+timeCreated: 1620202960

--- a/UOP1_Project/Assets/Scripts/Events/Input/JumpEvent.cs
+++ b/UOP1_Project/Assets/Scripts/Events/Input/JumpEvent.cs
@@ -1,0 +1,4 @@
+﻿public class JumpEvent
+{
+	public static readonly JumpEvent Event = new JumpEvent();
+}

--- a/UOP1_Project/Assets/Scripts/Events/Input/JumpEvent.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Events/Input/JumpEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 84d9f4250722426fa7bc2c12149efd65
+timeCreated: 1620202922

--- a/UOP1_Project/Assets/Scripts/Events/Input/MoveEvent.cs
+++ b/UOP1_Project/Assets/Scripts/Events/Input/MoveEvent.cs
@@ -1,0 +1,6 @@
+﻿using UnityEngine;
+
+public class MoveEvent
+{
+	public Vector2 Movement { get; set; }
+}

--- a/UOP1_Project/Assets/Scripts/Events/Input/MoveEvent.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Events/Input/MoveEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 47eee1f57b5045e1b4274885fd027656
+timeCreated: 1620203505

--- a/UOP1_Project/Assets/Scripts/Events/Input/OpenInventoryEvent.cs
+++ b/UOP1_Project/Assets/Scripts/Events/Input/OpenInventoryEvent.cs
@@ -1,0 +1,4 @@
+﻿public class OpenInventoryEvent
+{
+	public static readonly OpenInventoryEvent Event = new OpenInventoryEvent();
+}

--- a/UOP1_Project/Assets/Scripts/Events/Input/OpenInventoryEvent.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Events/Input/OpenInventoryEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d62d887de6d44e0f8b08d6b81c007969
+timeCreated: 1620204438

--- a/UOP1_Project/Assets/Scripts/Events/Input/StartedRunningEvent.cs
+++ b/UOP1_Project/Assets/Scripts/Events/Input/StartedRunningEvent.cs
@@ -1,0 +1,4 @@
+﻿public class StartedRunningEvent
+{
+	public static readonly StartedRunningEvent Event = new StartedRunningEvent();
+}

--- a/UOP1_Project/Assets/Scripts/Events/Input/StartedRunningEvent.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Events/Input/StartedRunningEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6f3c3f18caf845d2b79a6169d2119ba9
+timeCreated: 1620203920

--- a/UOP1_Project/Assets/Scripts/Events/Input/StoppedRunningEvent.cs
+++ b/UOP1_Project/Assets/Scripts/Events/Input/StoppedRunningEvent.cs
@@ -1,0 +1,4 @@
+﻿public class StoppedRunningEvent
+{
+	public static readonly StoppedRunningEvent Event = new StoppedRunningEvent();
+}

--- a/UOP1_Project/Assets/Scripts/Events/Input/StoppedRunningEvent.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Events/Input/StoppedRunningEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 676f9a7bbbb247079ddf7fe7ae2e493a
+timeCreated: 1620203958

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/EventAggregatorSO.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/EventAggregatorSO.cs
@@ -1,0 +1,22 @@
+﻿using UnityEngine;
+
+[CreateAssetMenu(fileName = "EventAggregatorSO", menuName = "Events/Event Aggregator")]
+public class EventAggregatorSO : ScriptableObject, IEventAggregator
+{
+	private readonly EventAggregator _eventAggregator = new EventAggregator();
+
+	public void Subscribe(object observer)
+	{
+		_eventAggregator.Subscribe(observer);
+	}
+
+	public void Unsubscribe(object observer)
+	{
+		_eventAggregator.Unsubscribe(observer);
+	}
+
+	public void Publish(object msg)
+	{
+		_eventAggregator.Publish(msg);
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/EventAggregatorSO.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/EventAggregatorSO.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c3683d4b74c443d4a48ca7b36086f246
+timeCreated: 1620199406

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/UnityEventBusSO.cs
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/UnityEventBusSO.cs
@@ -1,0 +1,23 @@
+﻿using UnityEngine;
+using UnityEngine.Events;
+
+[CreateAssetMenu(fileName = "UnityEventBusSO", menuName = "Events/Unity Event Bus")]
+public class UnityEventBusSO : ScriptableObject, IUnityEventBus
+{
+	private readonly UnityEventBus _unityEventBus = new UnityEventBus();
+
+	public void Subscribe<T>(UnityAction<T> action)
+	{
+		_unityEventBus.Subscribe(action);
+	}
+
+	public void Unsubscribe<T>(UnityAction<T> action)
+	{
+		_unityEventBus.Unsubscribe(action);
+	}
+
+	public void Publish<T>(T msg)
+	{
+		_unityEventBus.Publish(msg);
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/UnityEventBusSO.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Events/ScriptableObjects/UnityEventBusSO.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c44145970255443c86929d77c7ac2d2a
+timeCreated: 1620210159

--- a/UOP1_Project/Assets/Scripts/Events/UnityEventBus.cs
+++ b/UOP1_Project/Assets/Scripts/Events/UnityEventBus.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine.Events;
+
+/// <summary>
+/// Enables loose coupling of events from publishers to subscribers
+///
+/// A UnityAction based subscription where the T is event type used to find
+/// a suitable UnityAction.
+///
+/// Note the code is typesafe although somewhat ugly with HashSet<object> holder.
+///
+/// </summary>
+public interface IUnityEventBus
+{
+	public void Subscribe<T>(UnityAction<T> action);
+
+	public void Unsubscribe<T>(UnityAction<T> action);
+
+	public void Publish<T>(T msg);
+}
+
+public class UnityEventBus : IUnityEventBus
+{
+	private readonly Dictionary<Type, HashSet<object>> _handlers = new Dictionary<Type, HashSet<object>>();
+
+	public void Subscribe<T>(UnityAction<T> action)
+	{
+		if (action == null)
+		{
+			throw new ArgumentNullException(nameof(action));
+		}
+
+		var type = typeof(T);
+
+		if (!_handlers.TryGetValue(type, out var handlers))
+		{
+			handlers = new HashSet<object>();
+			_handlers[type] = handlers;
+		}
+
+		handlers.Add(action);
+	}
+
+	public void Unsubscribe<T>(UnityAction<T> action)
+	{
+		if (action == null)
+		{
+			throw new ArgumentNullException(nameof(action));
+		}
+
+		var type = typeof(T);
+
+		if (_handlers.TryGetValue(type, out var handlers))
+		{
+			handlers.Remove(action);
+		}
+	}
+
+	public void Publish<T>(T msg)
+	{
+		if (msg == null)
+		{
+			throw new ArgumentNullException(nameof(msg));
+		}
+
+		if (_handlers.TryGetValue(msg.GetType(), out var handlers))
+		{
+			foreach (var handler in handlers.Cast<UnityAction<T>>())
+			{
+				handler.Invoke(msg);
+			}
+		}
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Events/UnityEventBus.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Events/UnityEventBus.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e8373a96aa4c4bb1825d986bd9f75aa2
+timeCreated: 1620205812


### PR DESCRIPTION
A limited change to demonstrate events published from Input.

An EventAggregator was created and a SO to hold the instance so that it can be shared within the project.

The publishers were located in Inputs and for limited changes only those events that were applicable to Protagonist was applied.

Also there is a UnityEventBus that was created to avoid reflection and link to UnityActions that could be exposed to the inspector or an existing function can be used.  The later was demonstrated in the camera manager. 

