### PR TITLE
Fixed Settings menu not properly populating

### DIFF
--- a/UOP1_Project/Assets/Scripts/UI/UIPaginationFiller.cs
+++ b/UOP1_Project/Assets/Scripts/UI/UIPaginationFiller.cs
@@ -11,12 +11,16 @@ public class UIPaginationFiller : MonoBehaviour
 	[SerializeField] private Sprite _filledPagination = default;
 
 	private List<Image> _instantiatedImages = default;
+
 	private void Start()
 	{
-		_instantiatedImages = new List<Image>(); 
+		//_instantiatedImages = new List<Image>(); 
 	}
+
 	public void SetPagination(int paginationCount, int selectedPaginationIndex)
 	{
+		if (_instantiatedImages == null)
+			_instantiatedImages = new List<Image>();
 
 		//instanciate pagination images from the prefab
 		int maxCount = Mathf.Max(paginationCount, _instantiatedImages.Count);
@@ -42,7 +46,6 @@ public class UIPaginationFiller : MonoBehaviour
 
 				}
 			}
-
 			SetCurrentPagination(selectedPaginationIndex);
 		} 
 	}
@@ -60,12 +63,9 @@ public class UIPaginationFiller : MonoBehaviour
 				else
 				{
 					_instantiatedImages[i].sprite = _emptyPagination;
-
-
 				}
 			}
 		else
 			Debug.LogError("Error in pagination number"); 
-
 	}
 }


### PR DESCRIPTION
Moved the code that instantiates the _instantiatedImages to the SetPagination method.

Fixes #440  
Issue link: https://github.com/UnityTechnologies/open-project-1/issues/440
Forum thread: https://forum.unity.com/threads/settings-menu-not-properly-populated.1115938/

Fixed by moving the instantiation of the list of images to the SetPagination method. Since the instantiation only happens once, this should be ok.

To confirm the issue is resolved, open the Settings menu and confirm that the different options are displayed, and that no NullReferenceException is thrown.
