### PR TITLE
Add multi_compile keywords to CustomLighting.hlsl, remove ShaderGraph keywords

### DIFF
--- a/UOP1_Project/Assets/Shaders/Clouds.shadergraph
+++ b/UOP1_Project/Assets/Shaders/Clouds.shadergraph
@@ -3,23 +3,7 @@
     "m_Type": "UnityEditor.ShaderGraph.GraphData",
     "m_ObjectId": "c77fc8dd9d8d4db8b1bd5fba671e0fe3",
     "m_Properties": [],
-    "m_Keywords": [
-        {
-            "m_Id": "2abce56d53fd429bbc79dc24d83ffb37"
-        },
-        {
-            "m_Id": "9f8d9a85bdcb4f68a5fb26b7cd1f78e9"
-        },
-        {
-            "m_Id": "74a6cb339ad74937ad19bfa69db05921"
-        },
-        {
-            "m_Id": "3db5ad05ef5a4fefa0ea48820ebf7e22"
-        },
-        {
-            "m_Id": "3fb253ea24da4d64b8d16c5e332d382c"
-        }
-    ],
+    "m_Keywords": [],
     "m_Nodes": [
         {
             "m_Id": "362eb0f8b3456d8b97216c132b0725f4"
@@ -882,25 +866,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "2abce56d53fd429bbc79dc24d83ffb37",
-    "m_Guid": {
-        "m_GuidSerialized": "d08d37b3-65be-4f38-a392-53175e2213ad"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_BB033831_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.StepNode",
     "m_ObjectId": "2b20f109afb34b85a04909ef4a896b7f",
     "m_Group": {
@@ -1038,44 +1003,6 @@
     },
     "m_Labels": [],
     "m_Space": 0
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "3db5ad05ef5a4fefa0ea48820ebf7e22",
-    "m_Guid": {
-        "m_GuidSerialized": "c204b8e0-c510-4748-b4d6-f49e479d696c"
-    },
-    "m_Name": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_4674D99E_ON",
-    "m_OverrideReferenceName": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "3fb253ea24da4d64b8d16c5e332d382c",
-    "m_Guid": {
-        "m_GuidSerialized": "2ca03ba4-7089-44ef-ac5c-cfea0bc7cff2"
-    },
-    "m_Name": "LIGHTMAP",
-    "m_DefaultReferenceName": "BOOLEAN_B1D7753C_ON",
-    "m_OverrideReferenceName": "LIGHTMAP_ON",
-    "m_GeneratePropertyBlock": false,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
 }
 
 {
@@ -1228,25 +1155,6 @@
         "e32": 0.0,
         "e33": 1.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "74a6cb339ad74937ad19bfa69db05921",
-    "m_Guid": {
-        "m_GuidSerialized": "2deeea99-9649-4a79-9cf7-880150ddc8a4"
-    },
-    "m_Name": "_SHADOWS_SOFT",
-    "m_DefaultReferenceName": "BOOLEAN_93997D76_ON",
-    "m_OverrideReferenceName": "_SHADOWS_SOFT",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {
@@ -1779,25 +1687,6 @@
         "z": 0.0,
         "w": 0.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "9f8d9a85bdcb4f68a5fb26b7cd1f78e9",
-    "m_Guid": {
-        "m_GuidSerialized": "7a857902-c377-4b32-b851-0ac2aa3a5112"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_DefaultReferenceName": "BOOLEAN_BBB6BAB4_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {

--- a/UOP1_Project/Assets/Shaders/CustomHLSL/CustomLighting.hlsl
+++ b/UOP1_Project/Assets/Shaders/CustomHLSL/CustomLighting.hlsl
@@ -1,6 +1,19 @@
 ﻿#ifndef CUSTOM_LIGHTING_INCLUDED
 #define CUSTOM_LIGHTING_INCLUDED
 
+#if defined(SHADERGRAPH_PREVIEW)
+#else
+#pragma multi_compile _ _MAIN_LIGHT_SHADOWS
+#pragma multi_compile _ _MAIN_LIGHT_SHADOWS_CASCADE
+#pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
+#pragma multi_compile_fragment _ _ADDITIONAL_LIGHT_SHADOWS
+#pragma multi_compile_fragment _ _SHADOWS_SOFT
+#pragma multi_compile _ SHADOWS_SHADOWMASK
+#pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
+#pragma multi_compile _ LIGHTMAP_ON
+#pragma multi_compile _ LIGHTMAP_SHADOW_MIXING
+#endif
+
 void MainLight_float(float3 WorldPos, out float3 Direction, out float3 Color, out float ShadowAtten)
 {
 #if defined(SHADERGRAPH_PREVIEW)

--- a/UOP1_Project/Assets/Shaders/Toon.shadergraph
+++ b/UOP1_Project/Assets/Shaders/Toon.shadergraph
@@ -31,26 +31,7 @@
             "m_Id": "c7ddee4b9eaed98cb315fda2eafd5e7a"
         }
     ],
-    "m_Keywords": [
-        {
-            "m_Id": "83b2cd6b96bd47ccb15dd4b9093227cd"
-        },
-        {
-            "m_Id": "c6f36d1d675e42489687f623a2cd4333"
-        },
-        {
-            "m_Id": "c1c0d0aa391b4eb3aa5f379cba1ea29c"
-        },
-        {
-            "m_Id": "15e9bf6027e54dcfb3bd1be9753b9d11"
-        },
-        {
-            "m_Id": "7054160fb04e453dad4110ea4b0cbd59"
-        },
-        {
-            "m_Id": "319cea0d0678469d8244df0528635ec7"
-        }
-    ],
+    "m_Keywords": [],
     "m_Nodes": [
         {
             "m_Id": "7b58296a546e388389f1dca27ac980fb"
@@ -588,25 +569,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "15e9bf6027e54dcfb3bd1be9753b9d11",
-    "m_Guid": {
-        "m_GuidSerialized": "c204b8e0-c510-4748-b4d6-f49e479d696c"
-    },
-    "m_Name": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_4674D99E_ON",
-    "m_OverrideReferenceName": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
     "m_ObjectId": "182e498d588e508f9300b399a7e59ea9",
     "m_Id": -2098166363,
@@ -757,25 +719,6 @@
         "z": 0.0,
         "w": 0.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "319cea0d0678469d8244df0528635ec7",
-    "m_Guid": {
-        "m_GuidSerialized": "80fa6056-0ec3-4ce0-a0bb-32ab75571239"
-    },
-    "m_Name": "_ADDITIONAL_LIGHTS",
-    "m_DefaultReferenceName": "BOOLEAN_319CEA0D0678469D8244DF0528635EC7_ON",
-    "m_OverrideReferenceName": "_ADDITIONAL_LIGHTS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {
@@ -1097,25 +1040,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "7054160fb04e453dad4110ea4b0cbd59",
-    "m_Guid": {
-        "m_GuidSerialized": "2ca03ba4-7089-44ef-ac5c-cfea0bc7cff2"
-    },
-    "m_Name": "LIGHTMAP",
-    "m_DefaultReferenceName": "BOOLEAN_B1D7753C_ON",
-    "m_OverrideReferenceName": "LIGHTMAP_ON",
-    "m_GeneratePropertyBlock": false,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
     "m_ObjectId": "73134b94b6b6d9838eaa77400371075d",
     "m_Guid": {
@@ -1219,25 +1143,6 @@
     "m_Value": 0.5,
     "m_DefaultValue": 0.5,
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "83b2cd6b96bd47ccb15dd4b9093227cd",
-    "m_Guid": {
-        "m_GuidSerialized": "d08d37b3-65be-4f38-a392-53175e2213ad"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_BB033831_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {
@@ -1786,25 +1691,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "c1c0d0aa391b4eb3aa5f379cba1ea29c",
-    "m_Guid": {
-        "m_GuidSerialized": "2deeea99-9649-4a79-9cf7-880150ddc8a4"
-    },
-    "m_Name": "_SHADOWS_SOFT",
-    "m_DefaultReferenceName": "BOOLEAN_93997D76_ON",
-    "m_OverrideReferenceName": "_SHADOWS_SOFT",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
     "m_ObjectId": "c6e12f627ea0378f9a32f66f5aaab67a",
     "m_Id": -1085833363,
@@ -1828,25 +1714,6 @@
         "Y",
         "Z"
     ]
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "c6f36d1d675e42489687f623a2cd4333",
-    "m_Guid": {
-        "m_GuidSerialized": "7a857902-c377-4b32-b851-0ac2aa3a5112"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_DefaultReferenceName": "BOOLEAN_BBB6BAB4_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {

--- a/UOP1_Project/Assets/Shaders/Toon_DetailMaskTint.shadergraph
+++ b/UOP1_Project/Assets/Shaders/Toon_DetailMaskTint.shadergraph
@@ -34,23 +34,7 @@
             "m_Id": "ecb52c20140b5c8c9fb4d66f9a79a8b0"
         }
     ],
-    "m_Keywords": [
-        {
-            "m_Id": "8d18ce5158104394b2f9b1db9fc4738d"
-        },
-        {
-            "m_Id": "1e7a0d93fd134e9cb8f04c9efef79758"
-        },
-        {
-            "m_Id": "e680f1b5b59a4c5ba500453971e5e46c"
-        },
-        {
-            "m_Id": "221521992d5f4bc89ce48957365fdfeb"
-        },
-        {
-            "m_Id": "cc8ff02eae3b4b5e809bfbed679b0832"
-        }
-    ],
+    "m_Keywords": [],
     "m_Nodes": [
         {
             "m_Id": "b1224cdeaf4cdb82aec016db3e3c06ec"
@@ -515,44 +499,6 @@
         -1952668476,
         264816891
     ]
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "1e7a0d93fd134e9cb8f04c9efef79758",
-    "m_Guid": {
-        "m_GuidSerialized": "7a857902-c377-4b32-b851-0ac2aa3a5112"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_DefaultReferenceName": "BOOLEAN_BBB6BAB4_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "221521992d5f4bc89ce48957365fdfeb",
-    "m_Guid": {
-        "m_GuidSerialized": "c204b8e0-c510-4748-b4d6-f49e479d696c"
-    },
-    "m_Name": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_4674D99E_ON",
-    "m_OverrideReferenceName": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {
@@ -1166,25 +1112,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "8d18ce5158104394b2f9b1db9fc4738d",
-    "m_Guid": {
-        "m_GuidSerialized": "d08d37b3-65be-4f38-a392-53175e2213ad"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_BB033831_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
     "m_ObjectId": "8f9e6dde80df1183b64d55af6a72e212",
     "m_Id": 0,
@@ -1688,25 +1615,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "cc8ff02eae3b4b5e809bfbed679b0832",
-    "m_Guid": {
-        "m_GuidSerialized": "2ca03ba4-7089-44ef-ac5c-cfea0bc7cff2"
-    },
-    "m_Name": "LIGHTMAP",
-    "m_DefaultReferenceName": "BOOLEAN_B1D7753C_ON",
-    "m_OverrideReferenceName": "LIGHTMAP_ON",
-    "m_GeneratePropertyBlock": false,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BlockNode",
     "m_ObjectId": "d36fee74b93746ff917e7b7feb046df1",
     "m_Group": {
@@ -1960,25 +1868,6 @@
         "m_Guid": ""
     },
     "m_DefaultType": 0
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "e680f1b5b59a4c5ba500453971e5e46c",
-    "m_Guid": {
-        "m_GuidSerialized": "2deeea99-9649-4a79-9cf7-880150ddc8a4"
-    },
-    "m_Name": "_SHADOWS_SOFT",
-    "m_DefaultReferenceName": "BOOLEAN_93997D76_ON",
-    "m_OverrideReferenceName": "_SHADOWS_SOFT",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {

--- a/UOP1_Project/Assets/Shaders/Toon_Dissolve.shadergraph
+++ b/UOP1_Project/Assets/Shaders/Toon_Dissolve.shadergraph
@@ -52,23 +52,7 @@
             "m_Id": "ead61c8488b4408da50bac8d129fbd90"
         }
     ],
-    "m_Keywords": [
-        {
-            "m_Id": "b6b8f7fbe690419c9d151beece8626bd"
-        },
-        {
-            "m_Id": "926efd5d107741f4abf93e4116dc5c57"
-        },
-        {
-            "m_Id": "cfe57525bae04425bbd45a3e51077b29"
-        },
-        {
-            "m_Id": "1ead551e1f4f442b8e4a03cf6c08cd7c"
-        },
-        {
-            "m_Id": "0623608254954e3dbe663be4ac8acbfd"
-        }
-    ],
+    "m_Keywords": [],
     "m_Nodes": [
         {
             "m_Id": "2e186c9f6d357680a369c798dc672973"
@@ -761,25 +745,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "0623608254954e3dbe663be4ac8acbfd",
-    "m_Guid": {
-        "m_GuidSerialized": "2ca03ba4-7089-44ef-ac5c-cfea0bc7cff2"
-    },
-    "m_Name": "LIGHTMAP",
-    "m_DefaultReferenceName": "BOOLEAN_B1D7753C_ON",
-    "m_OverrideReferenceName": "LIGHTMAP_ON",
-    "m_GeneratePropertyBlock": false,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
     "m_ObjectId": "075c31bd14be178385d0c454cb292f2a",
     "m_Id": -2098166363,
@@ -1022,25 +987,6 @@
     "m_Labels": [
         "X"
     ]
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "1ead551e1f4f442b8e4a03cf6c08cd7c",
-    "m_Guid": {
-        "m_GuidSerialized": "c204b8e0-c510-4748-b4d6-f49e479d696c"
-    },
-    "m_Name": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_4674D99E_ON",
-    "m_OverrideReferenceName": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {
@@ -2475,25 +2421,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "926efd5d107741f4abf93e4116dc5c57",
-    "m_Guid": {
-        "m_GuidSerialized": "7a857902-c377-4b32-b851-0ac2aa3a5112"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_DefaultReferenceName": "BOOLEAN_BBB6BAB4_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.GroupData",
     "m_ObjectId": "944048838d03472b96985608e6f0d8a7",
     "m_Title": "Outline",
@@ -3023,25 +2950,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "b6b8f7fbe690419c9d151beece8626bd",
-    "m_Guid": {
-        "m_GuidSerialized": "d08d37b3-65be-4f38-a392-53175e2213ad"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_BB033831_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
     "m_ObjectId": "b974872d2ee7c388b6453d1151159925",
     "m_Group": {
@@ -3344,25 +3252,6 @@
     "m_Property": {
         "m_Id": "9219599e4ce16887a642a6414c442c09"
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "cfe57525bae04425bbd45a3e51077b29",
-    "m_Guid": {
-        "m_GuidSerialized": "2deeea99-9649-4a79-9cf7-880150ddc8a4"
-    },
-    "m_Name": "_SHADOWS_SOFT",
-    "m_DefaultReferenceName": "BOOLEAN_93997D76_ON",
-    "m_OverrideReferenceName": "_SHADOWS_SOFT",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {

--- a/UOP1_Project/Assets/Shaders/Toon_DoubleSided.shadergraph
+++ b/UOP1_Project/Assets/Shaders/Toon_DoubleSided.shadergraph
@@ -31,26 +31,7 @@
             "m_Id": "c7ddee4b9eaed98cb315fda2eafd5e7a"
         }
     ],
-    "m_Keywords": [
-        {
-            "m_Id": "83b2cd6b96bd47ccb15dd4b9093227cd"
-        },
-        {
-            "m_Id": "c6f36d1d675e42489687f623a2cd4333"
-        },
-        {
-            "m_Id": "c1c0d0aa391b4eb3aa5f379cba1ea29c"
-        },
-        {
-            "m_Id": "15e9bf6027e54dcfb3bd1be9753b9d11"
-        },
-        {
-            "m_Id": "7054160fb04e453dad4110ea4b0cbd59"
-        },
-        {
-            "m_Id": "319cea0d0678469d8244df0528635ec7"
-        }
-    ],
+    "m_Keywords": [],
     "m_Nodes": [
         {
             "m_Id": "7b58296a546e388389f1dca27ac980fb"
@@ -555,25 +536,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "15e9bf6027e54dcfb3bd1be9753b9d11",
-    "m_Guid": {
-        "m_GuidSerialized": "c204b8e0-c510-4748-b4d6-f49e479d696c"
-    },
-    "m_Name": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_4674D99E_ON",
-    "m_OverrideReferenceName": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
     "m_ObjectId": "182e498d588e508f9300b399a7e59ea9",
     "m_Id": -2098166363,
@@ -724,25 +686,6 @@
         "z": 0.0,
         "w": 0.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "319cea0d0678469d8244df0528635ec7",
-    "m_Guid": {
-        "m_GuidSerialized": "80fa6056-0ec3-4ce0-a0bb-32ab75571239"
-    },
-    "m_Name": "_ADDITIONAL_LIGHTS",
-    "m_DefaultReferenceName": "BOOLEAN_319CEA0D0678469D8244DF0528635EC7_ON",
-    "m_OverrideReferenceName": "_ADDITIONAL_LIGHTS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {
@@ -1097,25 +1040,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "7054160fb04e453dad4110ea4b0cbd59",
-    "m_Guid": {
-        "m_GuidSerialized": "2ca03ba4-7089-44ef-ac5c-cfea0bc7cff2"
-    },
-    "m_Name": "LIGHTMAP",
-    "m_DefaultReferenceName": "BOOLEAN_B1D7753C_ON",
-    "m_OverrideReferenceName": "LIGHTMAP_ON",
-    "m_GeneratePropertyBlock": false,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
     "m_ObjectId": "73134b94b6b6d9838eaa77400371075d",
     "m_Guid": {
@@ -1219,25 +1143,6 @@
     "m_Value": 0.5,
     "m_DefaultValue": 0.5,
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "83b2cd6b96bd47ccb15dd4b9093227cd",
-    "m_Guid": {
-        "m_GuidSerialized": "d08d37b3-65be-4f38-a392-53175e2213ad"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_BB033831_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {
@@ -1786,25 +1691,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "c1c0d0aa391b4eb3aa5f379cba1ea29c",
-    "m_Guid": {
-        "m_GuidSerialized": "2deeea99-9649-4a79-9cf7-880150ddc8a4"
-    },
-    "m_Name": "_SHADOWS_SOFT",
-    "m_DefaultReferenceName": "BOOLEAN_93997D76_ON",
-    "m_OverrideReferenceName": "_SHADOWS_SOFT",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
     "m_ObjectId": "c6e12f627ea0378f9a32f66f5aaab67a",
     "m_Id": -1085833363,
@@ -1828,25 +1714,6 @@
         "Y",
         "Z"
     ]
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "c6f36d1d675e42489687f623a2cd4333",
-    "m_Guid": {
-        "m_GuidSerialized": "7a857902-c377-4b32-b851-0ac2aa3a5112"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_DefaultReferenceName": "BOOLEAN_BBB6BAB4_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {

--- a/UOP1_Project/Assets/Shaders/Toon_Ground.shadergraph
+++ b/UOP1_Project/Assets/Shaders/Toon_Ground.shadergraph
@@ -43,21 +43,6 @@
     "m_Keywords": [
         {
             "m_Id": "dec8b5e7857f477085d4da98741dc028"
-        },
-        {
-            "m_Id": "eb37605e526c41de8786b11c3b68ebb0"
-        },
-        {
-            "m_Id": "7cbee5afde77470a88ff60693248f93b"
-        },
-        {
-            "m_Id": "276806f3ecc44546b361e42ee0a8534e"
-        },
-        {
-            "m_Id": "0d950a1ac4fc45bd89b82634a1f34d82"
-        },
-        {
-            "m_Id": "12118f0dbbdb44f0b71a4c8cdc2087cb"
         }
     ],
     "m_Nodes": [
@@ -624,44 +609,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "0d950a1ac4fc45bd89b82634a1f34d82",
-    "m_Guid": {
-        "m_GuidSerialized": "c204b8e0-c510-4748-b4d6-f49e479d696c"
-    },
-    "m_Name": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_4674D99E_ON",
-    "m_OverrideReferenceName": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "12118f0dbbdb44f0b71a4c8cdc2087cb",
-    "m_Guid": {
-        "m_GuidSerialized": "2ca03ba4-7089-44ef-ac5c-cfea0bc7cff2"
-    },
-    "m_Name": "LIGHTMAP",
-    "m_DefaultReferenceName": "BOOLEAN_B1D7753C_ON",
-    "m_OverrideReferenceName": "LIGHTMAP_ON",
-    "m_GeneratePropertyBlock": false,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "138b411c14f2e58387cd9b4b29b39272",
     "m_Group": {
@@ -857,25 +804,6 @@
     "m_Labels": [
         "X"
     ]
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "276806f3ecc44546b361e42ee0a8534e",
-    "m_Guid": {
-        "m_GuidSerialized": "2deeea99-9649-4a79-9cf7-880150ddc8a4"
-    },
-    "m_Name": "_SHADOWS_SOFT",
-    "m_DefaultReferenceName": "BOOLEAN_93997D76_ON",
-    "m_OverrideReferenceName": "_SHADOWS_SOFT",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
 }
 
 {
@@ -1490,25 +1418,6 @@
     "m_Property": {
         "m_Id": "0595504af65cb98f8bcc46a8c3a7817a"
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "7cbee5afde77470a88ff60693248f93b",
-    "m_Guid": {
-        "m_GuidSerialized": "7a857902-c377-4b32-b851-0ac2aa3a5112"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_DefaultReferenceName": "BOOLEAN_BBB6BAB4_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
 }
 
 {
@@ -2511,25 +2420,6 @@
     "m_Labels": [
         "X"
     ]
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "eb37605e526c41de8786b11c3b68ebb0",
-    "m_Guid": {
-        "m_GuidSerialized": "d08d37b3-65be-4f38-a392-53175e2213ad"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_BB033831_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
 }
 
 {

--- a/UOP1_Project/Assets/Shaders/Toon_RandomPositionTint.shadergraph
+++ b/UOP1_Project/Assets/Shaders/Toon_RandomPositionTint.shadergraph
@@ -40,26 +40,7 @@
             "m_Id": "954611dd2f07558ba201faf6492fea04"
         }
     ],
-    "m_Keywords": [
-        {
-            "m_Id": "73efb40aadc348b1bfdf82e57c472653"
-        },
-        {
-            "m_Id": "556a466d47324e74b05462351c62f0f8"
-        },
-        {
-            "m_Id": "11378866e5e94b0aa04e24a72d7f0363"
-        },
-        {
-            "m_Id": "4134ddf9c6fc464e81d62be1c9d2b220"
-        },
-        {
-            "m_Id": "f43a9ed79d034174af2d3e98b2c77e7e"
-        },
-        {
-            "m_Id": "122d589e8455484fbc9a60fe33e12a66"
-        }
-    ],
+    "m_Keywords": [],
     "m_Nodes": [
         {
             "m_Id": "6e1d8623d5957e8aaa209af36d125e8a"
@@ -399,44 +380,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "11378866e5e94b0aa04e24a72d7f0363",
-    "m_Guid": {
-        "m_GuidSerialized": "2deeea99-9649-4a79-9cf7-880150ddc8a4"
-    },
-    "m_Name": "_SHADOWS_SOFT",
-    "m_DefaultReferenceName": "BOOLEAN_93997D76_ON",
-    "m_OverrideReferenceName": "_SHADOWS_SOFT",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "122d589e8455484fbc9a60fe33e12a66",
-    "m_Guid": {
-        "m_GuidSerialized": "f1c88d18-496e-45c1-b7cd-f37bdac3acab"
-    },
-    "m_Name": "_ADDITIONAL_LIGHTS",
-    "m_DefaultReferenceName": "BOOLEAN_122D589E8455484FBC9A60FE33E12A66_ON",
-    "m_OverrideReferenceName": "_ADDITIONAL_LIGHTS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
     "m_ObjectId": "1246bfdb87927b848d8ff0c26d67d464",
     "m_Guid": {
@@ -767,25 +710,6 @@
 }
 
 {
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "4134ddf9c6fc464e81d62be1c9d2b220",
-    "m_Guid": {
-        "m_GuidSerialized": "c204b8e0-c510-4748-b4d6-f49e479d696c"
-    },
-    "m_Name": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_4674D99E_ON",
-    "m_OverrideReferenceName": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
     "m_SGVersion": 2,
     "m_Type": "UnityEditor.ShaderGraph.Internal.ColorShaderProperty",
     "m_ObjectId": "4504867913e8e289bd319d3cfcaa7111",
@@ -1008,25 +932,6 @@
         "w": 0.0
     },
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "556a466d47324e74b05462351c62f0f8",
-    "m_Guid": {
-        "m_GuidSerialized": "7a857902-c377-4b32-b851-0ac2aa3a5112"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_DefaultReferenceName": "BOOLEAN_BBB6BAB4_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {
@@ -1321,25 +1226,6 @@
         1837592865,
         -1085833363
     ]
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "73efb40aadc348b1bfdf82e57c472653",
-    "m_Guid": {
-        "m_GuidSerialized": "d08d37b3-65be-4f38-a392-53175e2213ad"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_BB033831_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {
@@ -1914,25 +1800,6 @@
     "m_Property": {
         "m_Id": "a600b4e254c2c088af0e3432f265e4f4"
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "f43a9ed79d034174af2d3e98b2c77e7e",
-    "m_Guid": {
-        "m_GuidSerialized": "2ca03ba4-7089-44ef-ac5c-cfea0bc7cff2"
-    },
-    "m_Name": "LIGHTMAP",
-    "m_DefaultReferenceName": "BOOLEAN_B1D7753C_ON",
-    "m_OverrideReferenceName": "LIGHTMAP_ON",
-    "m_GeneratePropertyBlock": false,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
 }
 
 {

--- a/UOP1_Project/Assets/Shaders/Toon_Rocks.shadergraph
+++ b/UOP1_Project/Assets/Shaders/Toon_Rocks.shadergraph
@@ -31,26 +31,7 @@
             "m_Id": "a600b4e254c2c088af0e3432f265e4f4"
         }
     ],
-    "m_Keywords": [
-        {
-            "m_Id": "73efb40aadc348b1bfdf82e57c472653"
-        },
-        {
-            "m_Id": "556a466d47324e74b05462351c62f0f8"
-        },
-        {
-            "m_Id": "11378866e5e94b0aa04e24a72d7f0363"
-        },
-        {
-            "m_Id": "4134ddf9c6fc464e81d62be1c9d2b220"
-        },
-        {
-            "m_Id": "f43a9ed79d034174af2d3e98b2c77e7e"
-        },
-        {
-            "m_Id": "122d589e8455484fbc9a60fe33e12a66"
-        }
-    ],
+    "m_Keywords": [],
     "m_Nodes": [
         {
             "m_Id": "6e1d8623d5957e8aaa209af36d125e8a"
@@ -1141,25 +1122,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "11378866e5e94b0aa04e24a72d7f0363",
-    "m_Guid": {
-        "m_GuidSerialized": "2deeea99-9649-4a79-9cf7-880150ddc8a4"
-    },
-    "m_Name": "_SHADOWS_SOFT",
-    "m_DefaultReferenceName": "BOOLEAN_93997D76_ON",
-    "m_OverrideReferenceName": "_SHADOWS_SOFT",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
     "m_ObjectId": "1179104817dc49718899e3539006af67",
     "m_Id": 2,
@@ -1204,25 +1166,6 @@
         "e32": 0.0,
         "e33": 1.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "122d589e8455484fbc9a60fe33e12a66",
-    "m_Guid": {
-        "m_GuidSerialized": "f1c88d18-496e-45c1-b7cd-f37bdac3acab"
-    },
-    "m_Name": "_ADDITIONAL_LIGHTS",
-    "m_DefaultReferenceName": "BOOLEAN_122D589E8455484FBC9A60FE33E12A66_ON",
-    "m_OverrideReferenceName": "_ADDITIONAL_LIGHTS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {
@@ -2431,25 +2374,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "4134ddf9c6fc464e81d62be1c9d2b220",
-    "m_Guid": {
-        "m_GuidSerialized": "c204b8e0-c510-4748-b4d6-f49e479d696c"
-    },
-    "m_Name": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_4674D99E_ON",
-    "m_OverrideReferenceName": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
     "m_ObjectId": "416c16fc6ef94410999c67bf7a018736",
     "m_Id": 2,
@@ -2785,25 +2709,6 @@
         "w": 0.0
     },
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "556a466d47324e74b05462351c62f0f8",
-    "m_Guid": {
-        "m_GuidSerialized": "7a857902-c377-4b32-b851-0ac2aa3a5112"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_DefaultReferenceName": "BOOLEAN_BBB6BAB4_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {
@@ -3704,25 +3609,6 @@
         "e32": 0.0,
         "e33": 1.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "73efb40aadc348b1bfdf82e57c472653",
-    "m_Guid": {
-        "m_GuidSerialized": "d08d37b3-65be-4f38-a392-53175e2213ad"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_BB033831_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {
@@ -5993,25 +5879,6 @@
     },
     "m_Labels": [],
     "m_Space": 4
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "f43a9ed79d034174af2d3e98b2c77e7e",
-    "m_Guid": {
-        "m_GuidSerialized": "2ca03ba4-7089-44ef-ac5c-cfea0bc7cff2"
-    },
-    "m_Name": "LIGHTMAP",
-    "m_DefaultReferenceName": "BOOLEAN_B1D7753C_ON",
-    "m_OverrideReferenceName": "LIGHTMAP_ON",
-    "m_GeneratePropertyBlock": false,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
 }
 
 {

--- a/UOP1_Project/Assets/Shaders/Toon_Slime.shadergraph
+++ b/UOP1_Project/Assets/Shaders/Toon_Slime.shadergraph
@@ -37,23 +37,7 @@
             "m_Id": "d74a1010ca32678890c72339b2c1bcd6"
         }
     ],
-    "m_Keywords": [
-        {
-            "m_Id": "260bdb872d44410ba436150202f0365d"
-        },
-        {
-            "m_Id": "996e09edc4da44d4ac98bea8df7f2a76"
-        },
-        {
-            "m_Id": "bebd0c0000fb4eeb8574d2340db207a7"
-        },
-        {
-            "m_Id": "c28f8a530a3340a09c40e11ebc4c275f"
-        },
-        {
-            "m_Id": "8f6a51a4482b45a69671c4205a5b2388"
-        }
-    ],
+    "m_Keywords": [],
     "m_Nodes": [
         {
             "m_Id": "ee6d4172871d2682a8aeed4079061e1e"
@@ -1183,25 +1167,6 @@
         "z": 0.0,
         "w": 0.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "260bdb872d44410ba436150202f0365d",
-    "m_Guid": {
-        "m_GuidSerialized": "40fed9b4-ea5d-4b6f-9bae-e9bd2a106828"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
 }
 
 {
@@ -2670,25 +2635,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "8f6a51a4482b45a69671c4205a5b2388",
-    "m_Guid": {
-        "m_GuidSerialized": "5df07f4a-ba53-4b32-a81a-a9ad0994e718"
-    },
-    "m_Name": "LIGHTMAP",
-    "m_DefaultReferenceName": "",
-    "m_OverrideReferenceName": "LIGHTMAP_ON",
-    "m_GeneratePropertyBlock": false,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.FresnelNode",
     "m_ObjectId": "91ee846703aa8a8bb10fd67c2a3a6247",
     "m_Group": {
@@ -2743,25 +2689,6 @@
     "m_Labels": [
         "X"
     ]
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "996e09edc4da44d4ac98bea8df7f2a76",
-    "m_Guid": {
-        "m_GuidSerialized": "a913735c-e586-47d9-a250-b9101949f896"
-    },
-    "m_Name": "_SHADOWS_SOFT",
-    "m_DefaultReferenceName": "",
-    "m_OverrideReferenceName": "_SHADOWS_SOFT",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
 }
 
 {
@@ -3266,44 +3193,6 @@
         "z": 0.0,
         "w": 0.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "bebd0c0000fb4eeb8574d2340db207a7",
-    "m_Guid": {
-        "m_GuidSerialized": "ebdd7e6e-b135-4d0c-9a37-43ca090b79fb"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_DefaultReferenceName": "",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "c28f8a530a3340a09c40e11ebc4c275f",
-    "m_Guid": {
-        "m_GuidSerialized": "7170a935-dc3c-463d-bda3-45d6ff6f9b1f"
-    },
-    "m_Name": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "",
-    "m_OverrideReferenceName": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
 }
 
 {

--- a/UOP1_Project/Assets/Shaders/Toon_Wind.shadergraph
+++ b/UOP1_Project/Assets/Shaders/Toon_Wind.shadergraph
@@ -37,23 +37,7 @@
             "m_Id": "15f42c78df36bc89ac42557c5f9607a3"
         }
     ],
-    "m_Keywords": [
-        {
-            "m_Id": "0d279796712a4e7b8f681ec84dd1b85e"
-        },
-        {
-            "m_Id": "50ea80a3cc854c068d1e2f9a3feab5e1"
-        },
-        {
-            "m_Id": "4f5e0980904d4cadb17a6251a023512a"
-        },
-        {
-            "m_Id": "babb98f1d9cc46dd960acc823193b73a"
-        },
-        {
-            "m_Id": "479c0139f0684a2384e422bd7caf94ab"
-        }
-    ],
+    "m_Keywords": [],
     "m_Nodes": [
         {
             "m_Id": "6e1d8623d5957e8aaa209af36d125e8a"
@@ -440,25 +424,6 @@
         "x": 10.0,
         "y": 10.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "0d279796712a4e7b8f681ec84dd1b85e",
-    "m_Guid": {
-        "m_GuidSerialized": "d08d37b3-65be-4f38-a392-53175e2213ad"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_BB033831_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {
@@ -1016,25 +981,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "479c0139f0684a2384e422bd7caf94ab",
-    "m_Guid": {
-        "m_GuidSerialized": "2ca03ba4-7089-44ef-ac5c-cfea0bc7cff2"
-    },
-    "m_Name": "LIGHTMAP",
-    "m_DefaultReferenceName": "BOOLEAN_B1D7753C_ON",
-    "m_OverrideReferenceName": "LIGHTMAP_ON",
-    "m_GeneratePropertyBlock": false,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
     "m_ObjectId": "4b626bab7baf9687bca029eafa88e521",
     "m_Id": 0,
@@ -1056,44 +1002,6 @@
         "w": 0.0
     },
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "4f5e0980904d4cadb17a6251a023512a",
-    "m_Guid": {
-        "m_GuidSerialized": "2deeea99-9649-4a79-9cf7-880150ddc8a4"
-    },
-    "m_Name": "_SHADOWS_SOFT",
-    "m_DefaultReferenceName": "BOOLEAN_93997D76_ON",
-    "m_OverrideReferenceName": "_SHADOWS_SOFT",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "50ea80a3cc854c068d1e2f9a3feab5e1",
-    "m_Guid": {
-        "m_GuidSerialized": "7a857902-c377-4b32-b851-0ac2aa3a5112"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_DefaultReferenceName": "BOOLEAN_BBB6BAB4_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {
@@ -1710,25 +1618,6 @@
         "m_SerializableColors": []
     },
     "m_SerializedDescriptor": "VertexDescription.Tangent"
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "babb98f1d9cc46dd960acc823193b73a",
-    "m_Guid": {
-        "m_GuidSerialized": "c204b8e0-c510-4748-b4d6-f49e479d696c"
-    },
-    "m_Name": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_4674D99E_ON",
-    "m_OverrideReferenceName": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {

--- a/UOP1_Project/Assets/Shaders/Unused/Toon_WithOutline.shadergraph
+++ b/UOP1_Project/Assets/Shaders/Unused/Toon_WithOutline.shadergraph
@@ -40,26 +40,7 @@
             "m_Id": "c7ddee4b9eaed98cb315fda2eafd5e7a"
         }
     ],
-    "m_Keywords": [
-        {
-            "m_Id": "83b2cd6b96bd47ccb15dd4b9093227cd"
-        },
-        {
-            "m_Id": "c6f36d1d675e42489687f623a2cd4333"
-        },
-        {
-            "m_Id": "c1c0d0aa391b4eb3aa5f379cba1ea29c"
-        },
-        {
-            "m_Id": "15e9bf6027e54dcfb3bd1be9753b9d11"
-        },
-        {
-            "m_Id": "7054160fb04e453dad4110ea4b0cbd59"
-        },
-        {
-            "m_Id": "319cea0d0678469d8244df0528635ec7"
-        }
-    ],
+    "m_Keywords": [],
     "m_Nodes": [
         {
             "m_Id": "7b58296a546e388389f1dca27ac980fb"
@@ -685,25 +666,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "15e9bf6027e54dcfb3bd1be9753b9d11",
-    "m_Guid": {
-        "m_GuidSerialized": "c204b8e0-c510-4748-b4d6-f49e479d696c"
-    },
-    "m_Name": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_4674D99E_ON",
-    "m_OverrideReferenceName": "_ADDITIONAL_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
     "m_ObjectId": "182e498d588e508f9300b399a7e59ea9",
     "m_Id": -2098166363,
@@ -919,25 +881,6 @@
         "z": 0.0,
         "w": 0.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "319cea0d0678469d8244df0528635ec7",
-    "m_Guid": {
-        "m_GuidSerialized": "80fa6056-0ec3-4ce0-a0bb-32ab75571239"
-    },
-    "m_Name": "_ADDITIONAL_LIGHTS",
-    "m_DefaultReferenceName": "BOOLEAN_319CEA0D0678469D8244DF0528635EC7_ON",
-    "m_OverrideReferenceName": "_ADDITIONAL_LIGHTS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {
@@ -1402,25 +1345,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "7054160fb04e453dad4110ea4b0cbd59",
-    "m_Guid": {
-        "m_GuidSerialized": "2ca03ba4-7089-44ef-ac5c-cfea0bc7cff2"
-    },
-    "m_Name": "LIGHTMAP",
-    "m_DefaultReferenceName": "BOOLEAN_B1D7753C_ON",
-    "m_OverrideReferenceName": "LIGHTMAP_ON",
-    "m_GeneratePropertyBlock": false,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
     "m_ObjectId": "73134b94b6b6d9838eaa77400371075d",
     "m_Guid": {
@@ -1559,25 +1483,6 @@
     "m_Property": {
         "m_Id": "984a3459fd7b1e8ea9ec09c2c1e80ff4"
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "83b2cd6b96bd47ccb15dd4b9093227cd",
-    "m_Guid": {
-        "m_GuidSerialized": "d08d37b3-65be-4f38-a392-53175e2213ad"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS",
-    "m_DefaultReferenceName": "BOOLEAN_BB033831_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {
@@ -2283,25 +2188,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "c1c0d0aa391b4eb3aa5f379cba1ea29c",
-    "m_Guid": {
-        "m_GuidSerialized": "2deeea99-9649-4a79-9cf7-880150ddc8a4"
-    },
-    "m_Name": "_SHADOWS_SOFT",
-    "m_DefaultReferenceName": "BOOLEAN_93997D76_ON",
-    "m_OverrideReferenceName": "_SHADOWS_SOFT",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
     "m_ObjectId": "c6e12f627ea0378f9a32f66f5aaab67a",
     "m_Id": -1085833363,
@@ -2325,25 +2211,6 @@
         "Y",
         "Z"
     ]
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "c6f36d1d675e42489687f623a2cd4333",
-    "m_Guid": {
-        "m_GuidSerialized": "7a857902-c377-4b32-b851-0ac2aa3a5112"
-    },
-    "m_Name": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_DefaultReferenceName": "BOOLEAN_BBB6BAB4_ON",
-    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS_CASCADE",
-    "m_GeneratePropertyBlock": true,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_Entries": [],
-    "m_Value": 1,
-    "m_IsEditable": true
 }
 
 {


### PR DESCRIPTION
This PR simplifies the ShaderGraph shaders: the multi_compile pragma can be in an include file, the keywords don't need to be declared separately on each Shader Graph. This is error prone, since someone could accidentally remove a keyword or use it in the graph incorrectly. Also, changing keywords (e.g. finding another one needs to be added to support lighting mode XY) is way harder if you have to hunt the keywords down in 10+ shaders.

The list of multi_compiles comes from URP's Lit.shader and contains a couple more items than were in ShaderGraph previously. I'm not sure if all lighting modes are used in Chop Chop but I think a more "complete" toon lighting can't hurt to have.

![image](https://user-images.githubusercontent.com/2693840/121101009-3f70ae00-c7fb-11eb-9040-a84e4bb1ef06.png)
