### PR TITLE
Bugfix slime hop

### DIFF
--- a/UOP1_Project/Assets/Prefabs/Characters/PlantCritter.prefab
+++ b/UOP1_Project/Assets/Prefabs/Characters/PlantCritter.prefab
@@ -69,9 +69,9 @@ CapsuleCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.5180242
-  m_Height: 5
+  m_Height: 2
   m_Direction: 1
-  m_Center: {x: -0.01654327, y: 2, z: 0.03308654}
+  m_Center: {x: -0.01654327, y: 0, z: 0.03308654}
 --- !u!136 &1330865802894030747
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -935,12 +935,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 415e24332f8993c4da4c452ed27d2873, type: 3}
---- !u!4 &7900849304968062265 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1745331680755163471, guid: 415e24332f8993c4da4c452ed27d2873,
-    type: 3}
-  m_PrefabInstance: {fileID: 8475173613595968630}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2154738241042901890 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7528600739965906932, guid: 415e24332f8993c4da4c452ed27d2873,
@@ -950,6 +944,12 @@ Transform:
 --- !u!4 &1577963483032510801 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6952379229305972007, guid: 415e24332f8993c4da4c452ed27d2873,
+    type: 3}
+  m_PrefabInstance: {fileID: 8475173613595968630}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &7618537762606215315 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -7194598512780364571, guid: 415e24332f8993c4da4c452ed27d2873,
     type: 3}
   m_PrefabInstance: {fileID: 8475173613595968630}
   m_PrefabAsset: {fileID: 0}
@@ -977,9 +977,9 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 8475173613595968630}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &7618537762606215315 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -7194598512780364571, guid: 415e24332f8993c4da4c452ed27d2873,
+--- !u!1 &8745063237678790951 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 415e24332f8993c4da4c452ed27d2873,
     type: 3}
   m_PrefabInstance: {fileID: 8475173613595968630}
   m_PrefabAsset: {fileID: 0}
@@ -995,27 +995,27 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 8475173613595968630}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &8221149608678237085 stripped
+--- !u!4 &7900849304968062265 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 415e24332f8993c4da4c452ed27d2873,
+  m_CorrespondingSourceObject: {fileID: 1745331680755163471, guid: 415e24332f8993c4da4c452ed27d2873,
     type: 3}
   m_PrefabInstance: {fileID: 8475173613595968630}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &8745063237678790951 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 415e24332f8993c4da4c452ed27d2873,
+--- !u!4 &3367916164164828314 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6566495199314442476, guid: 415e24332f8993c4da4c452ed27d2873,
     type: 3}
   m_PrefabInstance: {fileID: 8475173613595968630}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &5123279322988003801 stripped
+--- !u!4 &7492415303597500717 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -5583242968700353105, guid: 415e24332f8993c4da4c452ed27d2873,
+  m_CorrespondingSourceObject: {fileID: -7897143885434458789, guid: 415e24332f8993c4da4c452ed27d2873,
     type: 3}
   m_PrefabInstance: {fileID: 8475173613595968630}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &4188975802292468309 stripped
+--- !u!4 &7234782137268576505 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 5746564759562468899, guid: 415e24332f8993c4da4c452ed27d2873,
+  m_CorrespondingSourceObject: {fileID: -7927811463243438961, guid: 415e24332f8993c4da4c452ed27d2873,
     type: 3}
   m_PrefabInstance: {fileID: 8475173613595968630}
   m_PrefabAsset: {fileID: 0}
@@ -1049,9 +1049,9 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 8475173613595968630}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &7234782137268576505 stripped
+--- !u!4 &2333203040040827346 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -7927811463243438961, guid: 415e24332f8993c4da4c452ed27d2873,
+  m_CorrespondingSourceObject: {fileID: -3027282400719110748, guid: 415e24332f8993c4da4c452ed27d2873,
     type: 3}
   m_PrefabInstance: {fileID: 8475173613595968630}
   m_PrefabAsset: {fileID: 0}
@@ -1079,9 +1079,9 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 8475173613595968630}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &2333203040040827346 stripped
+--- !u!4 &5093156719673898483 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -3027282400719110748, guid: 415e24332f8993c4da4c452ed27d2873,
+  m_CorrespondingSourceObject: {fileID: -5533980067985051259, guid: 415e24332f8993c4da4c452ed27d2873,
     type: 3}
   m_PrefabInstance: {fileID: 8475173613595968630}
   m_PrefabAsset: {fileID: 0}
@@ -1097,21 +1097,21 @@ SkinnedMeshRenderer:
     type: 3}
   m_PrefabInstance: {fileID: 8475173613595968630}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &7492415303597500717 stripped
+--- !u!4 &4188975802292468309 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -7897143885434458789, guid: 415e24332f8993c4da4c452ed27d2873,
+  m_CorrespondingSourceObject: {fileID: 5746564759562468899, guid: 415e24332f8993c4da4c452ed27d2873,
     type: 3}
   m_PrefabInstance: {fileID: 8475173613595968630}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &3367916164164828314 stripped
+--- !u!4 &8221149608678237085 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 6566495199314442476, guid: 415e24332f8993c4da4c452ed27d2873,
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 415e24332f8993c4da4c452ed27d2873,
     type: 3}
   m_PrefabInstance: {fileID: 8475173613595968630}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &5093156719673898483 stripped
+--- !u!4 &5123279322988003801 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -5533980067985051259, guid: 415e24332f8993c4da4c452ed27d2873,
+  m_CorrespondingSourceObject: {fileID: -5583242968700353105, guid: 415e24332f8993c4da4c452ed27d2873,
     type: 3}
   m_PrefabInstance: {fileID: 8475173613595968630}
   m_PrefabAsset: {fileID: 0}

--- a/UOP1_Project/Assets/Prefabs/Characters/SlimeCritter.prefab
+++ b/UOP1_Project/Assets/Prefabs/Characters/SlimeCritter.prefab
@@ -70,7 +70,7 @@ SphereCollider:
   m_Enabled: 1
   serializedVersion: 2
   m_Radius: 0.35
-  m_Center: {x: 0, y: 0.32, z: 0}
+  m_Center: {x: 0, y: 0.37, z: 0}
 --- !u!135 &6274847306283701072
 SphereCollider:
   m_ObjectHideFlags: 0

--- a/UOP1_Project/Assets/Prefabs/Nature/Bush.prefab
+++ b/UOP1_Project/Assets/Prefabs/Nature/Bush.prefab
@@ -14,6 +14,169 @@ CapsuleCollider:
   m_Height: 1.3
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0.018966928}
+--- !u!114 &2994959601085690081
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2544298900655342970}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29c354ab60635420c83f79500cd7b617, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  collider: {fileID: 3892591581235103640}
+--- !u!1 &6334782100700203521
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 550757102349773509}
+  - component: {fileID: 3892591581235103640}
+  m_Layer: 0
+  m_Name: Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &550757102349773509
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6334782100700203521}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1513339394655935745}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &3892591581235103640
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6334782100700203521}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.5
+  m_Height: 1.6
+  m_Direction: 1
+  m_Center: {x: 0, y: 0.3, z: 0}
+--- !u!1001 &1466182808577421127
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2883705579607089088}
+    m_Modifications:
+    - target: {fileID: 96998187169542720, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: m_Radius
+      value: 0.49
+      objectReference: {fileID: 0}
+    - target: {fileID: 96998187169542720, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: m_Center.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 96998187169542721, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: _layers.m_Bits
+      value: 512
+      objectReference: {fileID: 0}
+    - target: {fileID: 96998187169542721, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: _enterZone.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 96998187169542721, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: _enterZone.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 96998187169542721, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: _enterZone.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 96998187169542721, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: _enterZone.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2994959601085690081}
+    - target: {fileID: 96998187169542721, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: _enterZone.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 2994959601085690081}
+    - target: {fileID: 96998187169542721, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: _enterZone.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 96998187169542721, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: _enterZone.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnObstacleTriggerChange
+      objectReference: {fileID: 0}
+    - target: {fileID: 96998187169542721, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: _enterZone.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: OnObstacleTriggerChange
+      objectReference: {fileID: 0}
+    - target: {fileID: 96998187169542721, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: _enterZone.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: Obstacle, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 96998187169542721, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: _enterZone.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: Obstacle, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 96998187169542721, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: _enterZone.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_BoolArgument
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 96998187169542721, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: _enterZone.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_BoolArgument
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 96998187169542721, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: _enterZone.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 96998187169542726, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 96998187169542727, guid: c823b09b59e206649a8779a78929fa2d,
+        type: 3}
+      propertyPath: m_Name
+      value: TriggerZone_Collide
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c823b09b59e206649a8779a78929fa2d, type: 3}
+--- !u!4 &1513339394655935745 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 96998187169542726, guid: c823b09b59e206649a8779a78929fa2d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1466182808577421127}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3426750649209436203
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -101,6 +264,12 @@ PrefabInstance:
 --- !u!1 &2544298900655342970 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 9659edb29993c4ba2a4f75b3265d81de,
+    type: 3}
+  m_PrefabInstance: {fileID: 3426750649209436203}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2883705579607089088 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 9659edb29993c4ba2a4f75b3265d81de,
     type: 3}
   m_PrefabInstance: {fileID: 3426750649209436203}
   m_PrefabAsset: {fileID: 0}

--- a/UOP1_Project/Assets/Scripts/Characters/Obstacle.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/Obstacle.cs
@@ -1,0 +1,13 @@
+using System;
+using UnityEngine;
+
+public class Obstacle : MonoBehaviour
+{
+    // This collider is disabled while the player is in the trigger area.
+    public Collider collider;
+
+    public void OnObstacleTriggerChange(bool entered, GameObject who)
+	{
+        collider.isTrigger = entered;
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Characters/Obstacle.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Characters/Obstacle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 29c354ab60635420c83f79500cd7b617
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Issue: https://github.com/UnityTechnologies/open-project-1/issues/426
Forum thread: https://forum.unity.com/threads/player-automatically-hops-on-slime-critter-when-walking-into-it.1107092/

Improved collision detection for a handful of game objects.

- Raised the slime critter's collider slightly, which eliminates the glitchy hopping behavior when the chef tries to walk near one.
- Decreased the height of the plant critters capsule collider, allowing the chef to hop over it without crashing into an invisible barrier.
- Gave the bush a tall capsule collider that "turns off" (becomes a trigger) when the player enters a trigger zone above the bush. This eliminates the hopping problem while still allowing the chef to jump over/onto the bush normally.

To test, enter a scene and try navigating near the objects listed above. When walking into them, the chef shouldn't hop or slide around. The chef should also be able to jump over/onto them without hitting an invisible barrier or hovering in midair. (You may want to disable the critters' state machines first so they don't keep trying to bite you.)