### PR TITLE
Add camera shake on protagonist hit.

### DIFF
--- a/UOP1_Project/Assets/Prefabs/Gameplay/CameraSystem.prefab
+++ b/UOP1_Project/Assets/Prefabs/Gameplay/CameraSystem.prefab
@@ -144,6 +144,79 @@ MonoBehaviour:
   m_AmplitudeGain: 0.3
   m_FrequencyGain: 0.2
   mNoiseOffsets: {x: 0, y: 0, z: 0}
+--- !u!1 &953227511577075091
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4798885055896967777}
+  - component: {fileID: 4256540570827347244}
+  m_Layer: 0
+  m_Name: ImpulseSource
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4798885055896967777
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 953227511577075091}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8745341640208226295}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4256540570827347244
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 953227511577075091}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 180ecf9b41d478f468eb3e9083753217, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ImpulseDefinition:
+    m_ImpulseChannel: 1
+    m_RawSignal: {fileID: 11400000, guid: 69ce8388f6785dd4c8c39915efece2f4, type: 2}
+    m_AmplitudeGain: 2
+    m_FrequencyGain: 1
+    m_RepeatMode: 0
+    m_Randomize: 1
+    m_TimeEnvelope:
+      m_AttackShape:
+        serializedVersion: 2
+        m_Curve: []
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      m_DecayShape:
+        serializedVersion: 2
+        m_Curve: []
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      m_AttackTime: 0
+      m_SustainTime: 0.2
+      m_DecayTime: 0.3
+      m_ScaleWithImpact: 1
+      m_HoldForever: 0
+    m_ImpactRadius: 100
+    m_DirectionMode: 0
+    m_DissipationMode: 2
+    m_DissipationDistance: 1000
+    m_PropagationSpeed: 343
 --- !u!1 &1988373824387590796
 GameObject:
   m_ObjectHideFlags: 0
@@ -813,6 +886,7 @@ Transform:
   - {fileID: 4438559601371693015}
   - {fileID: 8745341641394998850}
   - {fileID: 4399786004726619809}
+  - {fileID: 4798885055896967777}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -831,11 +905,13 @@ MonoBehaviour:
   inputReader: {fileID: 11400000, guid: 945ec0365077176418488737deed54be, type: 2}
   mainCamera: {fileID: 8745341642014614481}
   freeLookVCam: {fileID: 8745341641394998849}
+  impulseSource: {fileID: 4256540570827347244}
   _speedMultiplier: 1
   _cameraTransformAnchor: {fileID: 11400000, guid: bc205269957643647a8b5f98f028f9fb,
     type: 2}
   _frameObjectChannel: {fileID: 11400000, guid: 2723b3f59f7ede3498fe7e385d2bb6ee,
     type: 2}
+  _camShakeEvent: {fileID: 11400000, guid: 3d8e5223e1e74274cbb375151106b21e, type: 2}
 --- !u!1 &8745341641394998848
 GameObject:
   m_ObjectHideFlags: 0
@@ -847,6 +923,7 @@ GameObject:
   - component: {fileID: 8745341641394998850}
   - component: {fileID: 8745341641394998849}
   - component: {fileID: 643664704}
+  - component: {fileID: 7950225707197801264}
   m_Layer: 0
   m_Name: FreeLook_VCam
   m_TagString: Untagged
@@ -1005,6 +1082,22 @@ MonoBehaviour:
   m_Damping: 0.1
   m_DampingWhenOccluded: 0
   m_OptimalTargetDistance: 0
+--- !u!114 &7950225707197801264
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8745341641394998848}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00b2d199b96b516448144ab30fb26aed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ApplyAfter: 2
+  m_ChannelMask: 1
+  m_Gain: 1
+  m_Use2DDistance: 0
 --- !u!1 &8745341642014614487
 GameObject:
   m_ObjectHideFlags: 0

--- a/UOP1_Project/Assets/ScriptableObjects/Events/Camera.meta
+++ b/UOP1_Project/Assets/ScriptableObjects/Events/Camera.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1a2c17490504c5c4a909bdf1fdf956c8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/ScriptableObjects/Events/Camera/CameraShakeEvent.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/Events/Camera/CameraShakeEvent.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7fafac715ff920c4383fed91a38a351e, type: 3}
+  m_Name: CameraShakeEvent
+  m_EditorClassIdentifier: 
+  description: Event used to fire camera shake

--- a/UOP1_Project/Assets/ScriptableObjects/Events/Camera/CameraShakeEvent.asset.meta
+++ b/UOP1_Project/Assets/ScriptableObjects/Events/Camera/CameraShakeEvent.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3d8e5223e1e74274cbb375151106b21e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Critters/PlantCritter/States/GettingHit.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Critters/PlantCritter/States/GettingHit.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: c6283e9de49b5c243bc610ea00467646, type: 2}
   - {fileID: 11400000, guid: bb773df23fde8154e8c970004ac7e561, type: 2}
   - {fileID: 11400000, guid: 3df03613ad6365246bd2d591eddabc10, type: 2}
+  - {fileID: 11400000, guid: 45574b5ff344b8649b0749f764ad00af, type: 2}

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Critters/SlimeRockCritter/States/GettingHit.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Critters/SlimeRockCritter/States/GettingHit.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: c6283e9de49b5c243bc610ea00467646, type: 2}
   - {fileID: 11400000, guid: bb773df23fde8154e8c970004ac7e561, type: 2}
   - {fileID: 11400000, guid: 3df03613ad6365246bd2d591eddabc10, type: 2}
+  - {fileID: 11400000, guid: 45574b5ff344b8649b0749f764ad00af, type: 2}

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/Actions/ShakeCamAction.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/Actions/ShakeCamAction.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 63a903051ce61cb45a169b9074844fa9, type: 3}
+  m_Name: ShakeCamAction
+  m_EditorClassIdentifier: 
+  camShakeEvent: {fileID: 11400000, guid: 3d8e5223e1e74274cbb375151106b21e, type: 2}

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/Actions/ShakeCamAction.asset.meta
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/Actions/ShakeCamAction.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 45574b5ff344b8649b0749f764ad00af
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/GettingHit.asset
+++ b/UOP1_Project/Assets/ScriptableObjects/StateMachine/Protagonist/States/GettingHit.asset
@@ -17,3 +17,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 21788cba83bea9b49942b100edc2b832, type: 2}
   - {fileID: 11400000, guid: 374fbb8c166197a44b863aeded0c1fcc, type: 2}
   - {fileID: 11400000, guid: bbab1c59d57af344d95e166f153b21f9, type: 2}
+  - {fileID: 11400000, guid: 45574b5ff344b8649b0749f764ad00af, type: 2}

--- a/UOP1_Project/Assets/Scripts/Camera/CameraManager.cs
+++ b/UOP1_Project/Assets/Scripts/Camera/CameraManager.cs
@@ -8,6 +8,7 @@ public class CameraManager : MonoBehaviour
 	public InputReader inputReader;
 	public Camera mainCamera;
 	public CinemachineFreeLook freeLookVCam;
+	public CinemachineImpulseSource impulseSource;
 	private bool _isRMBPressed;
 
 	[SerializeField, Range(.5f, 3f)]
@@ -17,6 +18,8 @@ public class CameraManager : MonoBehaviour
 	[Header("Listening on channels")]
 	[Tooltip("The CameraManager listens to this event, fired by objects in any scene, to adapt camera position")]
 	[SerializeField] private TransformEventChannelSO _frameObjectChannel = default;
+	[Tooltip("The CameraManager listens to this event, fired by protagonist GettingHit state, to shake camera")]
+	[SerializeField] private VoidEventChannelSO _camShakeEvent = default;
 
 
 	private bool _cameraMovementLock = false;
@@ -36,6 +39,9 @@ public class CameraManager : MonoBehaviour
 
 		if (_frameObjectChannel != null)
 			_frameObjectChannel.OnEventRaised += OnFrameObjectEvent;
+
+		if (_camShakeEvent != null)
+			_camShakeEvent.OnEventRaised += () => impulseSource.GenerateImpulse();
 
 		_cameraTransformAnchor.Transform = mainCamera.transform;
 	}

--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/ShakeCamActionSO.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/ShakeCamActionSO.cs
@@ -1,0 +1,32 @@
+﻿using UnityEngine;
+using UOP1.StateMachine;
+using UOP1.StateMachine.ScriptableObjects;
+
+[CreateAssetMenu(fileName = "ShakeCamAction", menuName = "State Machines/Actions/Shake Cam Action")]
+public class ShakeCamActionSO : StateActionSO
+{
+	public VoidEventChannelSO camShakeEvent;
+	protected override StateAction CreateAction() => new ShakeCamAction();
+}
+
+public class ShakeCamAction : StateAction
+{
+	protected new ShakeCamActionSO OriginSO => (ShakeCamActionSO)base.OriginSO;
+
+	public override void Awake(StateMachine stateMachine)
+	{
+	}
+	
+	public override void OnUpdate()
+	{
+	}
+	
+	public override void OnStateEnter()
+	{
+		OriginSO.camShakeEvent.RaiseEvent();
+	}
+	
+	public override void OnStateExit()
+	{
+	}
+}

--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/ShakeCamActionSO.cs.meta
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/ShakeCamActionSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63a903051ce61cb45a169b9074844fa9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Feature described in this card:
https://open.codecks.io/unity-open-project-1/decks/15-code/card/1gk-camera-shake-on-hit

Added Action to GettingHit state, created Void Event Channel and raising it in OnStateEnter() of Action.
Created GO under CameraSystem with Impulse Source. Added reference to Impulse Source and Event SO to Camera Manager script and subscribed.