### PR TITLE
Stop audio cue when associated Component is destroyed

### DIFF
--- a/UOP1_Project/Assets/Scripts/Audio/AudioCue.cs
+++ b/UOP1_Project/Assets/Scripts/Audio/AudioCue.cs
@@ -27,6 +27,7 @@ public class AudioCue : MonoBehaviour
 	private void OnDisable()
 	{
 		_playOnStart = false;
+		StopAudioCue();
 	}
 
 	private IEnumerator PlayDelayed()


### PR DESCRIPTION
Issue: https://github.com/UnityTechnologies/open-project-1/issues/453
Codecks: https://open.codecks.io/unity-open-project-1/decks/13-bugs/card/1go-looping-sfx-are-still-playing-when-changing-scene
Forum: https://forum.unity.com/threads/suggestions-on-where-to-start.1127687/#post-7279576

Added a call to StopAudioCue() to the AudioCue script's OnDisable method.

To verify:
1. Start the Beach scene.
2. In the hierarchy explorer, go to PersistentManagers > AudioManager > SoundEmitterPool and note that one of its children is continuously playing the Env_Campfire audio clip.
3. Exit to Field_Hill. The campfire is no longer audible. The associated SoundEmitter may still be in the pool but is now disabled.
4. Return to the Beach. There is once again a SoundEmitter looping the campfire audio. (Possibly a different emitter in the pool than before.)