### PR TITLE
Fixed landing particles playing in air when attacking bug

### DIFF
--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/PlayLandParticlesActionSO.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/PlayLandParticlesActionSO.cs
@@ -10,6 +10,7 @@ public class PlayLandParticlesAction : StateAction
 	//Component references
 	private PlayerEffectController _dustController;
 	private Transform _transform;
+	private CharacterController _characterController;
 
 	private float _coolDown = 0.3f;
 	private float t = 0f;
@@ -22,6 +23,7 @@ public class PlayLandParticlesAction : StateAction
 	{
 		_dustController = stateMachine.GetComponent<PlayerEffectController>();
 		_transform = stateMachine.transform;
+		_characterController = stateMachine.GetComponent<CharacterController>();
 	}
 
 	public override void OnStateEnter()
@@ -35,7 +37,7 @@ public class PlayLandParticlesAction : StateAction
 		float dY = Mathf.Abs(_fallStartY - _fallEndY);
 		float fallIntensity = Mathf.InverseLerp(0, _maxFallDistance, dY);
 
-		if (Time.time >= t + _coolDown)
+		if (Time.time >= t + _coolDown && _characterController.isGrounded)
 		{
 			_dustController.PlayLandParticles(fallIntensity);
 			t = Time.time;


### PR DESCRIPTION
Issue:
https://open.codecks.io/unity-open-project-1/decks/13-bugs/card/1h2-landing-particles-and-sfx-play-when-attacking-in-the-air
Thread:
https://github.com/UnityTechnologies/open-project-1/issues/459

Like mentioned in the thread, the bug is caused because the state machine goes Ascending->Descending->DescendingAttacking where Descending calls the particles when exiting. I fixed this simply by adding a ground check on the PlayLandParticles action, so it cannot play in the air. The issue can be verified by playing the game, jumping and then attacking.