### PR TITLE
Update UIMenuManager.cs

### DIFF
--- a/UOP1_Project/Assets/Scripts/UI/UIMenuManager.cs
+++ b/UOP1_Project/Assets/Scripts/UI/UIMenuManager.cs
@@ -152,7 +152,7 @@ public class UIMenuManager : MonoBehaviour
 		if (quitConfirmed)
 		{
 			Application.Quit();
-			_onGameExitEvent.OnEventRaised();
+			_onGameExitEvent.RaiseEvent();
 		}
 		_mainMenuPanel.SetMenuScreen(_hasSaveData);
 


### PR DESCRIPTION
Summary:
Found a small bug, which was causing a NullReferenceException.

Bug ticket:
https://github.com/UnityTechnologies/open-project-1/issues/478

Forum Thread:
https://forum.unity.com/threads/bug-uimenumanager-throws-nullreferenceexception-on-game-exit.1142410/#post-7337182

Resolution:
Simple code modification, so we call RaiseEvent(), rather than OnEventRaised()

Verification Steps:
1. Launch game using editor play mode.
2. Using controller or keyboard and mouse:
3. Navigate back to the main menu
4. Attempt to exit the game
5. Observe the debug log

Result:
6. There are no NullReferenceException notifications in the log.