### PR TITLE
Implement: MainMenu->Exit stops Editor play mode

### DIFF
--- a/UOP1_Project/Assets/Scripts/UI/UIMenuManager.cs
+++ b/UOP1_Project/Assets/Scripts/UI/UIMenuManager.cs
@@ -151,10 +151,21 @@ public class UIMenuManager : MonoBehaviour
 		_popupPanel.gameObject.SetActive(false);
 		if (quitConfirmed)
 		{
-			Application.Quit();
-			_onGameExitEvent.OnEventRaised();
+			PerformQuit();
 		}
 		_mainMenuPanel.SetMenuScreen(_hasSaveData);
+
+
+	}
+	void PerformQuit()
+	{
+#if UNITY_EDITOR
+		UnityEditor.EditorApplication.isPlaying = false;
+#else
+		Application.Quit();
+#endif
+
+		_onGameExitEvent.RaiseEvent();
 
 
 	}


### PR DESCRIPTION
Forum Thread: https://forum.unity.com/threads/implementation-quitting-from-main-menu-stops-editor-play-mode.1142776/

What will this do?

Now, if you exit the game from the main menu, the editor will stop play mode


Why are these changes necessary?

These changes cause a clear response to occur, after the user exits the game.  Without a clear response from the program, it is more difficult to perform a QA smoketest.


How did you implement these changes?

1. Refactored quitting sequence into new method: void PerformQuit

2. Application.Quit doesn't work in editor, so we should use UnityEditor.EditorApplication.isPlaying = false, instead

NOTE: this PR includes the fix for https://github.com/UnityTechnologies/open-project-1/issues/478, which changes _onGameExitEvent.OnEventRaised()  to _onGameExitEvent.RaiseEvent()
