### PR TITLE
Fixed Scene Reloading issue in SceneLoader.cs

### DIFF
--- a/UOP1_Project/Assets/Scripts/SceneManagement/SceneLoader.cs
+++ b/UOP1_Project/Assets/Scripts/SceneManagement/SceneLoader.cs
@@ -80,6 +80,14 @@ public class SceneLoader : MonoBehaviour
 	/// </summary>
 	private void LoadLocation(GameSceneSO locationToLoad, bool showLoadingScreen, bool fadeScreen)
 	{
+		// To prevent reloading a location, as it gives Error that the scene asset has been already loaded.
+		// Thanks to stroibot for making me aware of this bug.
+		if (_currentlyLoadedScene == locationToLoad)
+		{
+			Debug.Log("Scene is already loaded, Doing nothing...", gameObject);
+			return;
+		}
+
 		//Prevent a double-loading, for situations where the player falls in two Exit colliders in one frame
 		if (_isLoading)
 			return;


### PR DESCRIPTION
Is this PR linked to an issue? If so please link it here, if not please create one first, then link it.  
Yes, it is: https://github.com/UnityTechnologies/open-project-1/issues/486

Is there a forum thread linked to this issue? If so please link it here.  
Yes, it is too: https://forum.unity.com/threads/reloading-scene-using-addressables.1149521/#post-7377545

How did you resolve this issue?  
Just by returning from the LoadLocation function if currentScene == LocationToLoad;

How can it be verified that the issue has actually been resolved?  
Maybe using this: https://forum.unity.com/threads/debug-system.1151783/
I also verified that this issue is reproduced and also that it is fixed using this.
Or the user [stroibot](https://forum.unity.com/members/stroibot.1297325/) on unity forums.
He made me aware of that bug.

Thanks.
