### PR TITLE
Fixed character movement stuck bug

### DIFF
--- a/UOP1_Project/Assets/Scripts/Characters/Protagonist.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/Protagonist.cs
@@ -11,6 +11,7 @@ public class Protagonist : MonoBehaviour
 
 	private Vector2 _inputVector;
 	private float _previousSpeed;
+	private double _lastHitTime = double.NegativeInfinity;
 
 	//These fields are read and manipulated by the StateMachine actions
 	[NonSerialized] public bool jumpInput;
@@ -30,7 +31,29 @@ public class Protagonist : MonoBehaviour
 
 	private void OnControllerColliderHit(ControllerColliderHit hit)
 	{
-		lastHit = hit;
+		bool isHitAccepted = false;
+		double time = Time.timeAsDouble;
+		if (_lastHitTime < time)
+		{
+			// New hit is in new frame, discard our outdated hit
+			isHitAccepted = true;
+		}
+		else
+		{
+			// Its the same frame, let's decide which hit to keep
+			if (lastHit.normal.y < hit.normal.y)
+			{
+				// New hit is pointing more upwards, more likely a floor hit
+				// We should prioritize floor hits over wall hits
+				isHitAccepted = true;
+			}
+		}
+
+		if(isHitAccepted)
+		{
+			lastHit = hit;
+			_lastHitTime = time;
+		}
 	}
 
 	//Adds listeners for events being triggered in the InputReader script


### PR DESCRIPTION
https://github.com/UnityTechnologies/open-project-1/issues/499

Solution: If OnControllerColliderHit occurs multiple times per frame (i.e. the CharacterController has multiple hits) then pick the hit with the highest normal.y value (i.e. pick the hits near the bottom of the capsule).

Explanation: Inside IsSlidingCondition.Statement(), the checks for step height and slope limit assumes there is only 1 hit per frame. However, if the player is standing on a flat surface and is touching a vertical wall. And, if the vertical wall's hit is last to be messaged. Then, the player could either slide directly upwards (which would unstuck the player) or downwards (which would cause the issue).

Verify: Reproduce the steps described in the issue.
