### PR TITLE
Kablouser/player sliding bugfix

### DIFF
--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/SlideActionSO.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/SlideActionSO.cs
@@ -7,6 +7,12 @@ public class SlideActionSO : StateActionSO<SlideAction> { }
 
 public class SlideAction : StateAction
 {
+	/// <summary>
+	/// Calculated by Cos(90-3 degrees) because 3 degrees is the problem begins
+	/// </summary>
+	const float FLAT_NORMAL_THRESHOLD = 0.05233595624f;
+	const float ADD_NORMAL_FACTOR = 0.1f;
+
 	private Protagonist _protagonist;
 
 	public override void Awake(StateMachine stateMachine)
@@ -21,9 +27,7 @@ public class SlideAction : StateAction
 		Vector3 biTangent = Vector3.Cross(hitNormal, Vector3.up);
 		Vector3 slideDirection = Vector3.Cross(hitNormal, biTangent);
 
-		const float FLAT_NORMAL_THRESHOLD = 0.1f;
-		const float ADD_NORMAL_FACTOR = 0.1f;
-		// Check if the normal is close to flat, this happens when the surface is too steep
+		// Check if the normal is close to flat/when the surface is too steep
 		if (Mathf.Abs(Vector3.Dot(hitNormal, Vector3.up)) < FLAT_NORMAL_THRESHOLD)
 		{
 			// Moving downwards now may cause the CharacterController to get stuck

--- a/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/SlideActionSO.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/StateMachine/Actions/SlideActionSO.cs
@@ -18,8 +18,19 @@ public class SlideAction : StateAction
 	{
 		float speed = -Physics.gravity.y * Protagonist.GRAVITY_MULTIPLIER * .4f;
 		Vector3 hitNormal = _protagonist.lastHit.normal;
-		Vector3 slideDirection = new Vector3(hitNormal.x, -hitNormal.y, hitNormal.z);
-		Vector3.OrthoNormalize(ref hitNormal, ref slideDirection);
+		Vector3 biTangent = Vector3.Cross(hitNormal, Vector3.up);
+		Vector3 slideDirection = Vector3.Cross(hitNormal, biTangent);
+
+		const float FLAT_NORMAL_THRESHOLD = 0.1f;
+		const float ADD_NORMAL_FACTOR = 0.1f;
+		// Check if the normal is close to flat, this happens when the surface is too steep
+		if (Mathf.Abs(Vector3.Dot(hitNormal, Vector3.up)) < FLAT_NORMAL_THRESHOLD)
+		{
+			// Moving downwards now may cause the CharacterController to get stuck
+			// Adding a small factor of the normal to the slideDirection fixes this issue
+			slideDirection += hitNormal * ADD_NORMAL_FACTOR;
+			slideDirection.Normalize();
+		}
 
 		//Trick below has been commented because it was pushing the character "into" the ground much too often,
 		//producing a collision, which would result in the character being stuck while in the Sliding state


### PR DESCRIPTION
https://github.com/UnityTechnologies/open-project-1/issues/416
https://github.com/UnityTechnologies/open-project-1/issues/499

I think the issue lies within CharacterController. When calling Move() with a downwards direction it can get stuck if it's close enough to a very vertical wall (but not exactly 90 degrees).

https://user-images.githubusercontent.com/45899999/134820485-1785d77a-bdd5-46ab-9a77-2c9491924fb7.mp4

My solution was to add a small push away from the wall when they are too steep.

https://user-images.githubusercontent.com/45899999/134820496-4efb6131-3be7-444d-b807-1daf0ad9f152.mp4

Verification: replicate steps described in the issues.