### PR TITLE
[Bugfix] Updated music volume and sfx volume values passed on setup

### DIFF
--- a/UOP1_Project/Assets/Scripts/Systems/Settings/UISettingsAudioComponent.cs
+++ b/UOP1_Project/Assets/Scripts/Systems/Settings/UISettingsAudioComponent.cs
@@ -38,7 +38,7 @@ public class UISettingsAudioComponent : MonoBehaviour
 	}
 	private void OnDisable()
 	{
-		ResetVolumes(); // reset volumes on disable. If not saved, it will reset to initial volumes. 
+		ResetVolumes(); // reset volumes on disable. If not saved, it will reset to initial volumes.
 		_musicVolumeField.OnNextOption -= IncreaseMusicVolume;
 		_musicVolumeField.OnPreviousOption -= DecreaseMusicVolume;
 		_saveButton.Clicked -= SaveVolumes;
@@ -52,8 +52,8 @@ public class UISettingsAudioComponent : MonoBehaviour
 	public void Setup(float musicVolume, float sfxVolume, float masterVolume)
 	{
 		_masterVolume = masterVolume;
-		_musicVolume = sfxVolume;
-		_sfxVolume = musicVolume;
+		_musicVolume = musicVolume;
+		_sfxVolume = sfxVolume;
 
 		_savedMasterVolume = _masterVolume;
 		_savedMusicVolume = _musicVolume;


### PR DESCRIPTION

**Description**
When saving the new audio settings and reopened, the new values are not reflected accordingly to the last saved in the UI Audio settings panel

**Expected behaviour**
Last saved settings should reflect in the Audio setting panel to change again from the last value.

Issue Link
https://github.com/UnityTechnologies/open-project-1/issues/516

