### PR TITLE
Fixed audio UI bug

### DIFF
--- a/UOP1_Project/Assets/Scripts/Systems/Settings/UISettingsAudioComponent.cs
+++ b/UOP1_Project/Assets/Scripts/Systems/Settings/UISettingsAudioComponent.cs
@@ -52,8 +52,8 @@ public class UISettingsAudioComponent : MonoBehaviour
 	public void Setup(float musicVolume, float sfxVolume, float masterVolume)
 	{
 		_masterVolume = masterVolume;
-		_musicVolume = sfxVolume;
-		_sfxVolume = musicVolume;
+		_musicVolume = musicVolume;
+		_sfxVolume = sfxVolume;
 
 		_savedMasterVolume = _masterVolume;
 		_savedMusicVolume = _musicVolume;


### PR DESCRIPTION
Issue: #516 

I found the location in UISettingsAudioComponent.cs where the music value is set to sfx, and vice versa. It is in the setup() function, which explains why it is switched every time the settings menu is opened.

After setting the music and sfx values, the player can exit the menu and the sound is reflected in the volume output. This process can be repeated over and over again with no bugs. Here is a video with proof that it works now: https://imgur.com/a/Tpa7CaU
