### PR TITLE
Fixed loading screen UI bug when aspect ratio is 21:9 or similar ultr…

### DIFF
--- a/UOP1_Project/Assets/Prefabs/Characters/NPCs_BasePrefabs/Gluecose.prefab
+++ b/UOP1_Project/Assets/Prefabs/Characters/NPCs_BasePrefabs/Gluecose.prefab
@@ -58,8 +58,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _attackConfigSO: {fileID: 11400000, guid: fa67200955f70e64abecdd0107951472, type: 2}
---- !u!135 &6188918218575104391
-SphereCollider:
+--- !u!65 &85085901128719611
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -69,9 +69,9 @@ SphereCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.35
-  m_Center: {x: 0, y: 0.32, z: 0}
---- !u!135 &6274847306283701072
+  m_Size: {x: 0.64422137, y: 0.5481757, z: 0.72591937}
+  m_Center: {x: -0.004921645, y: 0.2887556, z: 0.014988601}
+--- !u!135 &8467386107611288299
 SphereCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/UOP1_Project/Assets/Prefabs/Nature/Bush.prefab
+++ b/UOP1_Project/Assets/Prefabs/Nature/Bush.prefab
@@ -1,7 +1,7 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!136 &1143880073
-CapsuleCollider:
+--- !u!65 &306546508537069537
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -10,10 +10,9 @@ CapsuleCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
-  m_Radius: 0.5
-  m_Height: 1.3
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0.018966928}
+  serializedVersion: 2
+  m_Size: {x: 0.8377218, y: 0.55013984, z: 0.8510349}
+  m_Center: {x: -0.0015015602, y: 0.2526749, z: 0.011384085}
 --- !u!1 &6860398699643004296
 GameObject:
   m_ObjectHideFlags: 0
@@ -132,6 +131,11 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: 9659edb29993c4ba2a4f75b3265d81de,
         type: 3}
       propertyPath: m_Name
+      value: Bush
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 9659edb29993c4ba2a4f75b3265d81de,
+        type: 3}
+      propertyPath: m_TagString
       value: Bush
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 9659edb29993c4ba2a4f75b3265d81de,

--- a/UOP1_Project/Assets/Prefabs/Nature/BushThick2.prefab
+++ b/UOP1_Project/Assets/Prefabs/Nature/BushThick2.prefab
@@ -42,8 +42,8 @@ LightProbeGroup:
   m_SourcePositions:
   - {x: 0, y: 0.74264735, z: -0.00000002371987}
   m_Dering: 1
---- !u!136 &4946972002693030379
-CapsuleCollider:
+--- !u!65 &967800462607294721
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -52,10 +52,9 @@ CapsuleCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
-  m_Radius: 0.45
-  m_Height: 1.34
-  m_Direction: 0
-  m_Center: {x: 0, y: 0.18, z: 0}
+  serializedVersion: 2
+  m_Size: {x: 1.0791984, y: 0.5343887, z: 0.839382}
+  m_Center: {x: -0.025821447, y: 0.26473704, z: -0.022540838}
 --- !u!1001 &3596012594732811070
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -132,6 +131,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: BushThick2
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 1d579b5b4d7455941a284294eecc3c1d,
+        type: 3}
+      propertyPath: m_TagString
+      value: Bush
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 1d579b5b4d7455941a284294eecc3c1d,
         type: 3}

--- a/UOP1_Project/Assets/Scenes/Managers/PersistentManagers.unity
+++ b/UOP1_Project/Assets/Scenes/Managers/PersistentManagers.unity
@@ -593,6 +593,7 @@ GameObject:
   - component: {fileID: 1387982343}
   - component: {fileID: 1387982342}
   - component: {fileID: 1387982341}
+  - component: {fileID: 1387982340}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -600,6 +601,18 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!114 &1387982340
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1387982339}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14beef9872ff16d4f84de87287ee3c0d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1387982341
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UOP1_Project/Assets/Scenes/WIP/TestingGround_Slime.meta
+++ b/UOP1_Project/Assets/Scenes/WIP/TestingGround_Slime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ddb11dc917b9f834f8b429179eeeb6b6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scenes/WIP/TestingGround_Slime.unity
+++ b/UOP1_Project/Assets/Scenes/WIP/TestingGround_Slime.unity
@@ -1,0 +1,1706 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 1
+  m_FogColor: {r: 0.3028785, g: 0.67174834, b: 0.8113208, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.001
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.6463599, g: 0.69366497, b: 0.7830189, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.32489324, g: 0.36377177, b: 0.46226418, a: 1}
+  m_SkyboxMaterial: {fileID: 2100000, guid: 1c70868a2ca2d554d8b5c94cddde060c, type: 2}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.08579637, g: 0.3557556, b: 0.6398903, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 30
+    m_AtlasSize: 1024
+    m_AO: 1
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 0
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 1
+    m_BakeBackend: 2
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 1
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 2
+    m_PVRDenoiserTypeIndirect: 2
+    m_PVRDenoiserTypeAO: 2
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 0
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 112000000, guid: 9ace6b5f93f8ddf4ba36dffec3f895a7,
+    type: 2}
+  m_LightingSettings: {fileID: 4890085278179872738, guid: 52681ab8c7077404792ac20ee851382d,
+    type: 2}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 23800000, guid: 1652de92b0231a34ca380bb223279b4b, type: 2}
+--- !u!1 &59229076
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 59229080}
+  - component: {fileID: 59229079}
+  - component: {fileID: 59229078}
+  - component: {fileID: 59229077}
+  m_Layer: 0
+  m_Name: Ground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!64 &59229077
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 59229076}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &59229078
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 59229076}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 5f5129265f34a9b409029d1e565f1895, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &59229079
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 59229076}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &59229080
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 59229076}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &217050266
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2125786285293829329, guid: e978d53d440e0814086759404585ac32,
+        type: 3}
+      propertyPath: m_Name
+      value: SpawnSystem
+      objectReference: {fileID: 0}
+    - target: {fileID: 2125786285293829334, guid: e978d53d440e0814086759404585ac32,
+        type: 3}
+      propertyPath: _cameraManager
+      value: 
+      objectReference: {fileID: 1016146176}
+    - target: {fileID: 2125786285293829335, guid: e978d53d440e0814086759404585ac32,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2125786285293829335, guid: e978d53d440e0814086759404585ac32,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2125786285293829335, guid: e978d53d440e0814086759404585ac32,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2125786285293829335, guid: e978d53d440e0814086759404585ac32,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2125786285293829335, guid: e978d53d440e0814086759404585ac32,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2125786285293829335, guid: e978d53d440e0814086759404585ac32,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2125786285293829335, guid: e978d53d440e0814086759404585ac32,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2125786285293829335, guid: e978d53d440e0814086759404585ac32,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2125786285293829335, guid: e978d53d440e0814086759404585ac32,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2125786285293829335, guid: e978d53d440e0814086759404585ac32,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2125786285293829335, guid: e978d53d440e0814086759404585ac32,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e978d53d440e0814086759404585ac32, type: 3}
+--- !u!1001 &241674570
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1822371064}
+    m_Modifications:
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 14.450001
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -18.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 839268684819471456, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_Name
+      value: SlimeCritter (6)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 56a7aec3927ab6a4e85add83fc22eabb, type: 3}
+--- !u!4 &241674571 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+    type: 3}
+  m_PrefabInstance: {fileID: 241674570}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &242133391
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 242133393}
+  - component: {fileID: 242133392}
+  m_Layer: 0
+  m_Name: Light Probe Group
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!220 &242133392
+LightProbeGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 242133391}
+  m_Enabled: 1
+  m_SourcePositions:
+  - {x: 1, y: 1, z: 1}
+  - {x: 1, y: 1, z: -1}
+  - {x: 1, y: -1, z: 1}
+  - {x: 1, y: -1, z: -1}
+  - {x: -1, y: 1, z: 1}
+  - {x: -1, y: 1, z: -1}
+  - {x: -1, y: -1, z: 1}
+  - {x: -1, y: -1, z: -1}
+  m_Dering: 1
+--- !u!4 &242133393
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 242133391}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4.3061047, y: 1.44, z: -4.618569}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &258637418
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1822371064}
+    m_Modifications:
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.83
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -13.799999
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 839268684819471456, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_Name
+      value: SlimeCritter (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 56a7aec3927ab6a4e85add83fc22eabb, type: 3}
+--- !u!4 &258637419 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+    type: 3}
+  m_PrefabInstance: {fileID: 258637418}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &395747637
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 395747638}
+  m_Layer: 0
+  m_Name: ---------  ENVIRONMENT --------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &395747638
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 395747637}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &623728191
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1822371064}
+    m_Modifications:
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.79
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.41
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 839268684819471456, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_Name
+      value: SlimeCritter (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 56a7aec3927ab6a4e85add83fc22eabb, type: 3}
+--- !u!4 &623728192 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+    type: 3}
+  m_PrefabInstance: {fileID: 623728191}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &670201581
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 40564194958535835, guid: 54d1f8b93400ea64d97c276fab375df3,
+        type: 3}
+      propertyPath: m_Name
+      value: EditorInitializer
+      objectReference: {fileID: 0}
+    - target: {fileID: 40564194958535909, guid: 54d1f8b93400ea64d97c276fab375df3,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 40564194958535909, guid: 54d1f8b93400ea64d97c276fab375df3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 40564194958535909, guid: 54d1f8b93400ea64d97c276fab375df3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 40564194958535909, guid: 54d1f8b93400ea64d97c276fab375df3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 40564194958535909, guid: 54d1f8b93400ea64d97c276fab375df3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 40564194958535909, guid: 54d1f8b93400ea64d97c276fab375df3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 40564194958535909, guid: 54d1f8b93400ea64d97c276fab375df3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 40564194958535909, guid: 54d1f8b93400ea64d97c276fab375df3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 40564194958535909, guid: 54d1f8b93400ea64d97c276fab375df3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 40564194958535909, guid: 54d1f8b93400ea64d97c276fab375df3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 40564194958535909, guid: 54d1f8b93400ea64d97c276fab375df3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7222522106795826365, guid: 54d1f8b93400ea64d97c276fab375df3,
+        type: 3}
+      propertyPath: _thisSceneSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 7713c45402e4e7c4a8ae2d8c3e8689f2,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 54d1f8b93400ea64d97c276fab375df3, type: 3}
+--- !u!1 &677320529
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 677320530}
+  m_Layer: 0
+  m_Name: Nature
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &677320530
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 677320529}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -13.37435, y: 0.0024575493, z: -16.984669}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1419381495}
+  - {fileID: 861049989}
+  - {fileID: 1661197624}
+  - {fileID: 1924113029}
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &695792052
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 695792053}
+  m_Layer: 0
+  m_Name: ---------  MANAGERS --------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &695792053
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 695792052}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &803850211
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8791488512559450800, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18,
+        type: 3}
+      propertyPath: m_Name
+      value: Sun_Directional_Morning
+      objectReference: {fileID: 0}
+    - target: {fileID: 8791488512559450802, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8791488512559450802, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8791488512559450802, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 8791488512559450802, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8791488512559450802, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9281887
+      objectReference: {fileID: 0}
+    - target: {fileID: 8791488512559450802, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.35388622
+      objectReference: {fileID: 0}
+    - target: {fileID: 8791488512559450802, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.06748072
+      objectReference: {fileID: 0}
+    - target: {fileID: 8791488512559450802, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.09314904
+      objectReference: {fileID: 0}
+    - target: {fileID: 8791488512559450802, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 42.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 8791488512559450802, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -4.582
+      objectReference: {fileID: 0}
+    - target: {fileID: 8791488512559450802, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 9.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8791488512559450803, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18,
+        type: 3}
+      propertyPath: m_BoundingSphereOverride.w
+      value: 4.0286167e-11
+      objectReference: {fileID: 0}
+    - target: {fileID: 8791488512559450803, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18,
+        type: 3}
+      propertyPath: m_BoundingSphereOverride.x
+      value: 6.61e-43
+      objectReference: {fileID: 0}
+    - target: {fileID: 8791488512559450803, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18,
+        type: 3}
+      propertyPath: m_BoundingSphereOverride.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8791488512559450803, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18,
+        type: 3}
+      propertyPath: m_BoundingSphereOverride.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8cd2f4ad3ae032047aaaf5fe0254cb18, type: 3}
+--- !u!1 &826602623
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 826602624}
+  m_Layer: 0
+  m_Name: ---------  LIGHTING --------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &826602624
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 826602623}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &861049988
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 677320530}
+    m_Modifications:
+    - target: {fileID: 2758915572059324437, guid: 410782ac32370144dbb0fabfcd95242b,
+        type: 3}
+      propertyPath: m_Name
+      value: CloudBush
+      objectReference: {fileID: 0}
+    - target: {fileID: 3243281902740937391, guid: 410782ac32370144dbb0fabfcd95242b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3243281902740937391, guid: 410782ac32370144dbb0fabfcd95242b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.5073814
+      objectReference: {fileID: 0}
+    - target: {fileID: 3243281902740937391, guid: 410782ac32370144dbb0fabfcd95242b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.08475855
+      objectReference: {fileID: 0}
+    - target: {fileID: 3243281902740937391, guid: 410782ac32370144dbb0fabfcd95242b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.80963707
+      objectReference: {fileID: 0}
+    - target: {fileID: 3243281902740937391, guid: 410782ac32370144dbb0fabfcd95242b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3243281902740937391, guid: 410782ac32370144dbb0fabfcd95242b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3243281902740937391, guid: 410782ac32370144dbb0fabfcd95242b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3243281902740937391, guid: 410782ac32370144dbb0fabfcd95242b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3243281902740937391, guid: 410782ac32370144dbb0fabfcd95242b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3243281902740937391, guid: 410782ac32370144dbb0fabfcd95242b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3243281902740937391, guid: 410782ac32370144dbb0fabfcd95242b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 410782ac32370144dbb0fabfcd95242b, type: 3}
+--- !u!4 &861049989 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3243281902740937391, guid: 410782ac32370144dbb0fabfcd95242b,
+    type: 3}
+  m_PrefabInstance: {fileID: 861049988}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1016146176 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8745341640208226294, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1810604289}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 085156cba0e34b540aeddafe12d1e2f1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1315316205
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1822371064}
+    m_Modifications:
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -13.799999
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 839268684819471456, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_Name
+      value: SlimeCritter (4)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 56a7aec3927ab6a4e85add83fc22eabb, type: 3}
+--- !u!4 &1315316206 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+    type: 3}
+  m_PrefabInstance: {fileID: 1315316205}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1419381494
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 677320530}
+    m_Modifications:
+    - target: {fileID: 2544298900655342970, guid: 1337199faacc8e24487ea9f049e7294e,
+        type: 3}
+      propertyPath: m_Name
+      value: Bush
+      objectReference: {fileID: 0}
+    - target: {fileID: 2544298900655342970, guid: 1337199faacc8e24487ea9f049e7294e,
+        type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883705579607089088, guid: 1337199faacc8e24487ea9f049e7294e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883705579607089088, guid: 1337199faacc8e24487ea9f049e7294e,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.21836
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883705579607089088, guid: 1337199faacc8e24487ea9f049e7294e,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.21836
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883705579607089088, guid: 1337199faacc8e24487ea9f049e7294e,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.21836
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883705579607089088, guid: 1337199faacc8e24487ea9f049e7294e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.10564995
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883705579607089088, guid: 1337199faacc8e24487ea9f049e7294e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0024575493
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883705579607089088, guid: 1337199faacc8e24487ea9f049e7294e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.4746685
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883705579607089088, guid: 1337199faacc8e24487ea9f049e7294e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883705579607089088, guid: 1337199faacc8e24487ea9f049e7294e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.000000021855694
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883705579607089088, guid: 1337199faacc8e24487ea9f049e7294e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883705579607089088, guid: 1337199faacc8e24487ea9f049e7294e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883705579607089088, guid: 1337199faacc8e24487ea9f049e7294e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883705579607089088, guid: 1337199faacc8e24487ea9f049e7294e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883705579607089088, guid: 1337199faacc8e24487ea9f049e7294e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1337199faacc8e24487ea9f049e7294e, type: 3}
+--- !u!4 &1419381495 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2883705579607089088, guid: 1337199faacc8e24487ea9f049e7294e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1419381494}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1523164311
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1523164312}
+  m_Layer: 0
+  m_Name: ---------  GAMEPLAY --------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1523164312
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1523164311}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1613675738
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1822371064}
+    m_Modifications:
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.5300002
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -20.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 839268684819471456, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_Name
+      value: SlimeCritter (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2611611568870205161, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2794913305780075582, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8215897978565536066, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 56a7aec3927ab6a4e85add83fc22eabb, type: 3}
+--- !u!4 &1613675739 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+    type: 3}
+  m_PrefabInstance: {fileID: 1613675738}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1661197623
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 677320530}
+    m_Modifications:
+    - target: {fileID: 6969277432125349962, guid: 08b343eb55b90fd4abc76bb429f0cdb5,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969277432125349962, guid: 08b343eb55b90fd4abc76bb429f0cdb5,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.07806
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969277432125349962, guid: 08b343eb55b90fd4abc76bb429f0cdb5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.001624749
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969277432125349962, guid: 08b343eb55b90fd4abc76bb429f0cdb5,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.0646687
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969277432125349962, guid: 08b343eb55b90fd4abc76bb429f0cdb5,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969277432125349962, guid: 08b343eb55b90fd4abc76bb429f0cdb5,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.000000021855694
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969277432125349962, guid: 08b343eb55b90fd4abc76bb429f0cdb5,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969277432125349962, guid: 08b343eb55b90fd4abc76bb429f0cdb5,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969277432125349962, guid: 08b343eb55b90fd4abc76bb429f0cdb5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969277432125349962, guid: 08b343eb55b90fd4abc76bb429f0cdb5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969277432125349962, guid: 08b343eb55b90fd4abc76bb429f0cdb5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7781103373470284528, guid: 08b343eb55b90fd4abc76bb429f0cdb5,
+        type: 3}
+      propertyPath: m_Name
+      value: BushThick3
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 08b343eb55b90fd4abc76bb429f0cdb5, type: 3}
+--- !u!4 &1661197624 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6969277432125349962, guid: 08b343eb55b90fd4abc76bb429f0cdb5,
+    type: 3}
+  m_PrefabInstance: {fileID: 1661197623}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1810604289
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1657732992883833910, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1657732992883833910, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.99914324
+      objectReference: {fileID: 0}
+    - target: {fileID: 1657732992883833910, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.04138582
+      objectReference: {fileID: 0}
+    - target: {fileID: 1657732992883833910, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.000000004827175
+      objectReference: {fileID: 0}
+    - target: {fileID: 1657732992883833910, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -5.374562e-10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2808035858438402709, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2808035858438402709, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9949196
+      objectReference: {fileID: 0}
+    - target: {fileID: 2808035858438402709, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.100672774
+      objectReference: {fileID: 0}
+    - target: {fileID: 2808035858438402709, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.0000000025147626
+      objectReference: {fileID: 0}
+    - target: {fileID: 2808035858438402709, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -4.3305604e-10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2955398947125553842, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2955398947125553842, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2955398947125553842, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2955398947125553842, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.99204165
+      objectReference: {fileID: 0}
+    - target: {fileID: 2955398947125553842, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.12591039
+      objectReference: {fileID: 0}
+    - target: {fileID: 2955398947125553842, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.0000000036750398
+      objectReference: {fileID: 0}
+    - target: {fileID: 2955398947125553842, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 7.2666695e-10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341640208226293, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_Name
+      value: CameraSystem
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341640208226295, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341640208226295, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341640208226295, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341640208226295, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341640208226295, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341640208226295, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341640208226295, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341640208226295, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341640208226295, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341640208226295, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341640208226295, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341641394998850, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341641394998850, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341642014614481, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: field of view
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341642014614481, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: orthographic size
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9971113
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.07595423
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.00000001715797
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745341642014614482, guid: 45632f0a227c860489bcba0eb1f4ec3e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.0000000013067998
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 45632f0a227c860489bcba0eb1f4ec3e, type: 3}
+--- !u!1 &1822371063
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1822371064}
+  m_Layer: 0
+  m_Name: Critters
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1822371064
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1822371063}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5.52, y: 0.08, z: 12.78}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 258637419}
+  - {fileID: 1613675739}
+  - {fileID: 623728192}
+  - {fileID: 1315316206}
+  - {fileID: 1982577295}
+  - {fileID: 241674571}
+  m_Father: {fileID: 0}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1924113028
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 677320530}
+    m_Modifications:
+    - target: {fileID: 3921829447138550997, guid: 18449ebb78e19ad478f2a355f7198188,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3921829447138550997, guid: 18449ebb78e19ad478f2a355f7198188,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3921829447138550997, guid: 18449ebb78e19ad478f2a355f7198188,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3921829447138550997, guid: 18449ebb78e19ad478f2a355f7198188,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3921829447138550997, guid: 18449ebb78e19ad478f2a355f7198188,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3921829447138550997, guid: 18449ebb78e19ad478f2a355f7198188,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.000000021855694
+      objectReference: {fileID: 0}
+    - target: {fileID: 3921829447138550997, guid: 18449ebb78e19ad478f2a355f7198188,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3921829447138550997, guid: 18449ebb78e19ad478f2a355f7198188,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3921829447138550997, guid: 18449ebb78e19ad478f2a355f7198188,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3921829447138550997, guid: 18449ebb78e19ad478f2a355f7198188,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3921829447138550997, guid: 18449ebb78e19ad478f2a355f7198188,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4406477252211801711, guid: 18449ebb78e19ad478f2a355f7198188,
+        type: 3}
+      propertyPath: m_Name
+      value: BushThick2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 18449ebb78e19ad478f2a355f7198188, type: 3}
+--- !u!4 &1924113029 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3921829447138550997, guid: 18449ebb78e19ad478f2a355f7198188,
+    type: 3}
+  m_PrefabInstance: {fileID: 1924113028}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1982577294
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1822371064}
+    m_Modifications:
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 839268684819471456, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+        type: 3}
+      propertyPath: m_Name
+      value: SlimeCritter (5)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 56a7aec3927ab6a4e85add83fc22eabb, type: 3}
+--- !u!4 &1982577295 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 67130409962850010, guid: 56a7aec3927ab6a4e85add83fc22eabb,
+    type: 3}
+  m_PrefabInstance: {fileID: 1982577294}
+  m_PrefabAsset: {fileID: 0}

--- a/UOP1_Project/Assets/Scenes/WIP/TestingGround_Slime.unity.meta
+++ b/UOP1_Project/Assets/Scenes/WIP/TestingGround_Slime.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7b2ccd49c1a8aba448bd231032e52fa4
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/Scripts/Characters/Protagonist.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/Protagonist.cs
@@ -12,6 +12,9 @@ public class Protagonist : MonoBehaviour
 	private Vector2 _inputVector;
 	private float _previousSpeed;
 
+	// For the slime/bush hopping bug: sets the max distance between player and object allowed when colliders clip
+	public float maxDistance = 0.5f;
+
 	//These fields are read and manipulated by the StateMachine actions
 	[NonSerialized] public bool jumpInput;
 	[NonSerialized] public bool extraActionInput;
@@ -136,4 +139,27 @@ public class Protagonist : MonoBehaviour
 
 	// Triggered from Animation Event
 	public void ConsumeAttackInput() => attackInput = false;
+
+	//---- Slime/bush hopping fail-safe ----
+    private void OnCollisionStay(Collision collision)
+    {
+		// If the player has continued contact with a critter or bush object
+        if (collision.gameObject.tag == "Critter" || collision.gameObject.tag == "Bush")
+        {
+			// Calculates the distance between the player and the object
+            float distance = Vector3.Distance(collision.gameObject.transform.position, this.transform.position);
+			// Checks if colliders are clipping
+            if (distance <= maxDistance)
+            {
+				// Calculates the direction between the player and object
+                Vector3 direction = collision.gameObject.transform.position - this.transform.position;
+				// Sets vertical direction to 0, to prevent hopping
+                direction.y = 0f;
+
+                // Calculates new position for player to move outside of clipped collider based on direction
+                Vector3 newPos = this.transform.position + direction.normalized * (maxDistance - distance);
+				this.transform.position = Vector3.Lerp(this.transform.position, newPos, Time.deltaTime);
+            }
+        }
+    }
 }

--- a/UOP1_Project/Assets/Scripts/UI/UIScaling.cs
+++ b/UOP1_Project/Assets/Scripts/UI/UIScaling.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class UIScaling : MonoBehaviour
+{
+    // Gets the necessary canvas object
+    private CanvasScaler scaler;
+
+    // Gets the display's width and height in pixel size
+    private int width = Screen.width;
+    private int height = Screen.height;
+
+    private void Start()
+    {
+        scaler = GetComponent<CanvasScaler>();                                      // Gets the necessary component for scaling modification
+
+        scaler.referenceResolution = new Vector2(width, height);                    // Ensures the UI is sized according to screen pixel data
+        scaler.screenMatchMode = CanvasScaler.ScreenMatchMode.MatchWidthOrHeight;   // Matches the UI to referenced screen size
+    }
+}

--- a/UOP1_Project/Assets/Scripts/UI/UIScaling.cs.meta
+++ b/UOP1_Project/Assets/Scripts/UI/UIScaling.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14beef9872ff16d4f84de87287ee3c0d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UOP1_Project/Assets/WIP/Materials/Grass_ForUnitPlane.mat
+++ b/UOP1_Project/Assets/WIP/Materials/Grass_ForUnitPlane.mat
@@ -33,6 +33,10 @@ Material:
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
+    - Texture2D_300EB541:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _BaseMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
@@ -69,7 +73,20 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     m_Floats:
+    - Vector1_8606F96E: 0
     - _AlphaClip: 0
     - _Blend: 0
     - _BumpScale: 1
@@ -106,3 +123,4 @@ Material:
     - _SpecularColor: {r: 0, g: 0, b: 0, a: 0}
     - _SpecularColor1: {r: 0, g: 0, b: 0, a: 0}
     - _Tiling: {r: 15, g: 15, b: 0, a: 0}
+  m_BuildTextureStacks: []

--- a/UOP1_Project/ProjectSettings/QualitySettings.asset
+++ b/UOP1_Project/ProjectSettings/QualitySettings.asset
@@ -21,7 +21,7 @@ QualitySettings:
     skinWeights: 4
     textureQuality: 0
     anisotropicTextures: 1
-    antiAliasing: 2
+    antiAliasing: 0
     softParticles: 0
     softVegetation: 1
     realtimeReflectionProbes: 1

--- a/UOP1_Project/ProjectSettings/TagManager.asset
+++ b/UOP1_Project/ProjectSettings/TagManager.asset
@@ -11,6 +11,7 @@ TagManager:
   - Critter
   - ChickInLantern
   - AudioManager
+  - Bush
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
This PR addresses both issues #426 and #518.

For #426, I changed the colliders on problematic objects like slimes and small bushes from sphere colliders to box colliders. I downsized the box colliders to be slightly smaller than the actual object so as to make it as functionally close to a spherical collider as possible. This removes the possibility for the player to slide up the sphere's upper slope when moving too close to it. I also added some fail-safe code at the bottom of Protagonist.cs, where I check the distance between the player and bush/critter objects (identified by appropriate tags in Unity) to see if the objects are clipping (i.e. their colliders are overlapping), and lerping the player just outside of the object's collider if so. 
For #518, I made a new script, UIScaling.cs, and attached it to the Canvas object which contains the loading screen. In this script, I gets the screen's width and height, and readjust the canvas size to reference this size and scale to it, so that it works for any resolution.

Here are two videos demonstrating the fix for #426, one where I try running up on, walking up on, and hitting bushes from different angles, and another where I do the same to a slime. In both videos and all my testing, I was unable to replicate the bug as before.
https://user-images.githubusercontent.com/73858910/233730332-5c8a69ab-3be9-48ea-9b59-b79478e1eeaf.mp4
https://user-images.githubusercontent.com/73858910/233730349-cf34f59a-d895-4802-b96f-00fd8ec89677.mp4

Here is a video demonstrating the fix for #518, where I load the loading screen in first 16:9 aspect ratio, then 21:9 aspect ratio, then 21:5 aspect ratio. For all ratios, the loading screen looked the same, demonstrating how it now scales properly for all kinds of displays.
https://user-images.githubusercontent.com/73858910/233730873-6759e569-04e2-4eb2-81ea-d0f3de290bcb.mp4


