### PR TITLE
Fixed UI scaling bug for different aspect ratios

### DIFF
--- a/UOP1_Project/Assets/Scripts/UI/UIScaling.cs
+++ b/UOP1_Project/Assets/Scripts/UI/UIScaling.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class UIScaling : MonoBehaviour
+{
+    // Gets the necessary canvas object
+    private CanvasScaler scaler;
+
+    // Gets the display's width and height in pixel size
+    private int width = Screen.width;
+    private int height = Screen.height;
+
+    private void Start()
+    {
+        scaler = GetComponent<CanvasScaler>();                                      // Gets the necessary component for scaling modification
+
+        scaler.referenceResolution = new Vector2(width, height);                    // Ensures the UI is sized according to screen pixel data
+        scaler.screenMatchMode = CanvasScaler.ScreenMatchMode.MatchWidthOrHeight;   // Matches the UI to referenced screen size
+    }
+}

--- a/UOP1_Project/Assets/Scripts/UI/UIScaling.cs.meta
+++ b/UOP1_Project/Assets/Scripts/UI/UIScaling.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14beef9872ff16d4f84de87287ee3c0d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR addresses issue #518.

To fix it, I made a new script, UIScaling.cs, and attached it to the Canvas object which contains the loading screen. In this script, I gets the screen's width and height, and readjust the canvas size to reference this size and scale to it, so that it works for any resolution.

Here is a video demonstrating this fix, where I load the loading screen in first 16:9 aspect ratio, then 21:9 aspect ratio, then 21:5 aspect ratio. For all ratios, the loading screen looked the same, demonstrating how it now scales properly for all kinds of displays.
https://user-images.githubusercontent.com/73858910/233741803-7608340c-85b0-46cf-a1c4-b2fcb2337ded.mp4