### PR TITLE
Fixed rock sliding bug

### DIFF
--- a/UOP1_Project/Assets/Scripts/Characters/Protagonist.cs
+++ b/UOP1_Project/Assets/Scripts/Characters/Protagonist.cs
@@ -109,6 +109,26 @@ public class Protagonist : MonoBehaviour
 		_previousSpeed = targetSpeed;
 	}
 
+	// Ensure that player does not get stuck in corners/edges of rocks
+	void OnCollisionEnter(Collision collisionInfo)
+    {
+        if (collisionInfo.gameObject.name.Contains("rock") ||
+			collisionInfo.gameObject.name.Contains("Rock")){
+			
+			// While colliding with a rock, increase character controller slope limit
+			GetComponent<CharacterController>().slopeLimit = 90;
+		}
+    }
+	void OnCollisionExit(Collision collisionInfo)
+	{
+		if (collisionInfo.gameObject.name.Contains("rock") ||
+			collisionInfo.gameObject.name.Contains("Rock")){
+			
+			// After colliding with a rock, decrease character controller slope limit
+			GetComponent<CharacterController>().slopeLimit = 50;
+		}
+	}
+
 	//---- EVENT LISTENERS ----
 
 	private void OnMove(Vector2 movement)


### PR DESCRIPTION
This PR addresses issue #499.

I noticed that, while the player is stuck on the rock, adjusting the minimum slope on the characterController to be around 90 allowed the player to move again. Therefore, I decided to implement a failsafe in Protagonist.cs that detects when the player is colliding with a rock, and if so, sets the minimum slope value to 90. When they leave the rock collider, the minimum slope is set back to its original value. Although this does not necessarily address the root of this bug, I found that it made for a good temporary fix.

After implementing the changes, this is how the character and rocks behaved on my laptop: https://imgur.com/a/l1vArnX
